### PR TITLE
fix(lake): bounded TTL cache for RSS dedup, reduce memory pressure

### DIFF
--- a/lake/internal/ingest/rss_collector.go
+++ b/lake/internal/ingest/rss_collector.go
@@ -25,9 +25,13 @@ import (
 
 const (
 	rssUserAgent      = "lake-rss/1.0 (+https://github.com/solanyn/mono)"
-	maxConcurrency    = 10
+	maxConcurrency    = 4
 	minDomainInterval = time.Second
 	minExtractLen     = 200
+	maxArticleBytes   = 2 * 1024 * 1024 // 2MB per article (was 10MB)
+	seenTTL           = 24 * time.Hour
+	seenMaxSize       = 50000
+	startupStagger    = 5 * time.Second // per-feed stagger on startup
 )
 
 type ArticleEvent struct {
@@ -57,8 +61,7 @@ type RSSCollector struct {
 	producer *kafka.Producer
 	bucket   string
 	cron     *cron.Cron
-	seen     map[string]struct{}
-	mu       sync.Mutex
+	seen     *TTLCache
 	sem      chan struct{}
 	domains  map[string]time.Time
 	domainMu sync.Mutex
@@ -72,7 +75,7 @@ func NewRSSCollector(s3 *storage.Client, producer *kafka.Producer, bucket string
 		producer: producer,
 		bucket:   bucket,
 		cron:     cron.New(cron.WithLocation(loc)),
-		seen:     make(map[string]struct{}),
+		seen:     NewTTLCache(seenTTL, seenMaxSize),
 		sem:      make(chan struct{}, maxConcurrency),
 		domains:  make(map[string]time.Time),
 		client: &http.Client{
@@ -94,17 +97,20 @@ func (c *RSSCollector) Start() {
 		secs := int(f.Interval.Seconds())
 		expr := fmt.Sprintf("@every %ds", secs)
 
-		time.AfterFunc(jitter+time.Duration(i)*time.Second, func() {
+		// Stagger startup over minutes to avoid burst of concurrent fetches
+		delay := jitter + time.Duration(i)*startupStagger
+		time.AfterFunc(delay, func() {
 			c.processFeed(f)
 			c.cron.AddFunc(expr, func() { c.processFeed(f) })
 		})
 	}
 	c.cron.Start()
-	log.Printf("rss_collector: started with %d feeds", len(Feeds))
+	log.Printf("rss_collector: started with %d feeds (stagger=%s)", len(Feeds), startupStagger)
 }
 
 func (c *RSSCollector) Stop() {
 	c.cron.Stop()
+	c.seen.Stop()
 }
 
 func (c *RSSCollector) processFeed(feed Feed) {
@@ -144,15 +150,10 @@ func (c *RSSCollector) processFeed(feed Feed) {
 		guid := itemGUID(item)
 		dedupeKey := feed.Slug + "|" + guid
 
-		c.mu.Lock()
-		_, seen := c.seen[dedupeKey]
-		if !seen {
-			c.seen[dedupeKey] = struct{}{}
-		}
-		c.mu.Unlock()
-		if seen {
+		if c.seen.Has(dedupeKey) {
 			continue
 		}
+		c.seen.Set(dedupeKey)
 
 		published := itemPublished(item)
 		author := itemAuthor(item)
@@ -310,7 +311,7 @@ func (c *RSSCollector) fetchURL(ctx context.Context, rawURL string) ([]byte, err
 		return nil, fmt.Errorf("http %d: %s", resp.StatusCode, rawURL)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArticleBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/lake/internal/ingest/rss_collector_test.go
+++ b/lake/internal/ingest/rss_collector_test.go
@@ -1,0 +1,123 @@
+package ingest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRSSCollector_Constants(t *testing.T) {
+	// Verify the tuned constants are what we expect
+	if maxConcurrency != 4 {
+		t.Errorf("maxConcurrency should be 4, got %d", maxConcurrency)
+	}
+	if maxArticleBytes != 2*1024*1024 {
+		t.Errorf("maxArticleBytes should be 2MB, got %d", maxArticleBytes)
+	}
+	if seenTTL != 24*time.Hour {
+		t.Errorf("seenTTL should be 24h, got %s", seenTTL)
+	}
+	if seenMaxSize != 50000 {
+		t.Errorf("seenMaxSize should be 50000, got %d", seenMaxSize)
+	}
+	if startupStagger != 5*time.Second {
+		t.Errorf("startupStagger should be 5s, got %s", startupStagger)
+	}
+}
+
+func TestRSSCollector_SeenDedup(t *testing.T) {
+	// Simulate the dedup logic from processFeed
+	seen := NewTTLCache(time.Hour, 1000)
+	defer seen.Stop()
+
+	feed := Feed{Slug: "test-feed"}
+	guid1 := "article-1"
+	guid2 := "article-2"
+
+	key1 := feed.Slug + "|" + guid1
+	key2 := feed.Slug + "|" + guid2
+
+	// First encounter — not seen
+	if seen.Has(key1) {
+		t.Error("key1 should not be seen yet")
+	}
+	seen.Set(key1)
+
+	// Second encounter — should be deduped
+	if !seen.Has(key1) {
+		t.Error("key1 should be seen after Set")
+	}
+
+	// Different article — not seen
+	if seen.Has(key2) {
+		t.Error("key2 should not be seen yet")
+	}
+
+	// Same GUID, different feed — not seen (slug prefix differentiates)
+	otherKey := "other-feed|" + guid1
+	if seen.Has(otherKey) {
+		t.Error("same GUID in different feed should not collide")
+	}
+}
+
+func TestRSSCollector_SeenExpiry(t *testing.T) {
+	// After TTL, articles should be re-fetchable (not permanently deduped)
+	seen := NewTTLCache(50*time.Millisecond, 1000)
+	defer seen.Stop()
+
+	key := "feed|old-article"
+	seen.Set(key)
+
+	if !seen.Has(key) {
+		t.Fatal("should be seen immediately")
+	}
+
+	time.Sleep(80 * time.Millisecond)
+
+	if seen.Has(key) {
+		t.Error("should have expired after TTL — article can be re-ingested")
+	}
+}
+
+func TestItemGUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		guid     string
+		link     string
+		expected string
+	}{
+		{"has guid", "abc-123", "https://example.com/post", "abc-123"},
+		{"empty guid falls back to link", "", "https://example.com/post", "https://example.com/post"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Can't easily construct gofeed.Item here without the dep,
+			// but we test the logic inline
+			guid := tt.guid
+			if guid == "" {
+				guid = tt.link
+			}
+			if guid != tt.expected {
+				t.Errorf("got %q, want %q", guid, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input    string
+		max      int
+		expected string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello"},
+		{"", 5, ""},
+		{"abc", 3, "abc"},
+	}
+	for _, tt := range tests {
+		got := truncate(tt.input, tt.max)
+		if got != tt.expected {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.expected)
+		}
+	}
+}

--- a/lake/internal/ingest/ttlcache.go
+++ b/lake/internal/ingest/ttlcache.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"sync"
+	"time"
+)
+
+// TTLCache is a map with per-entry expiration. Entries are lazily evicted
+// during Set/Has calls and periodically via a background reaper.
+type TTLCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+	ttl     time.Duration
+	maxSize int
+	stop    chan struct{}
+}
+
+// NewTTLCache creates a cache where entries expire after ttl. If the cache
+// exceeds maxSize, the oldest entries are evicted on the next Set call.
+// A background goroutine reaps expired entries every ttl/2.
+func NewTTLCache(ttl time.Duration, maxSize int) *TTLCache {
+	c := &TTLCache{
+		entries: make(map[string]time.Time),
+		ttl:     ttl,
+		maxSize: maxSize,
+		stop:    make(chan struct{}),
+	}
+	go c.reaper()
+	return c
+}
+
+// Set adds or refreshes a key.
+func (c *TTLCache) Set(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = time.Now()
+	if len(c.entries) > c.maxSize {
+		c.evictOldestLocked(len(c.entries) - c.maxSize)
+	}
+}
+
+// Has returns true if the key exists and hasn't expired.
+func (c *TTLCache) Has(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+	if time.Since(t) > c.ttl {
+		delete(c.entries, key)
+		return false
+	}
+	return true
+}
+
+// Len returns the number of entries (including possibly expired ones).
+func (c *TTLCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// Stop terminates the background reaper.
+func (c *TTLCache) Stop() {
+	close(c.stop)
+}
+
+func (c *TTLCache) reaper() {
+	interval := c.ttl / 2
+	if interval < 50*time.Millisecond {
+		interval = 50 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.evictExpired()
+		case <-c.stop:
+			return
+		}
+	}
+}
+
+func (c *TTLCache) evictExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for k, t := range c.entries {
+		if now.Sub(t) > c.ttl {
+			delete(c.entries, k)
+		}
+	}
+}
+
+func (c *TTLCache) evictOldestLocked(n int) {
+	type entry struct {
+		key string
+		t   time.Time
+	}
+	// Find the n oldest entries
+	for i := 0; i < n; i++ {
+		var oldest entry
+		first := true
+		for k, t := range c.entries {
+			if first || t.Before(oldest.t) {
+				oldest = entry{k, t}
+				first = false
+			}
+		}
+		if !first {
+			delete(c.entries, oldest.key)
+		}
+	}
+}

--- a/lake/internal/ingest/ttlcache_test.go
+++ b/lake/internal/ingest/ttlcache_test.go
@@ -1,0 +1,128 @@
+package ingest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTTLCache_SetAndHas(t *testing.T) {
+	c := NewTTLCache(time.Hour, 1000)
+	defer c.Stop()
+
+	c.Set("a")
+	c.Set("b")
+
+	if !c.Has("a") {
+		t.Error("expected 'a' to be present")
+	}
+	if !c.Has("b") {
+		t.Error("expected 'b' to be present")
+	}
+	if c.Has("c") {
+		t.Error("expected 'c' to be absent")
+	}
+}
+
+func TestTTLCache_Expiry(t *testing.T) {
+	c := NewTTLCache(50*time.Millisecond, 1000)
+	defer c.Stop()
+
+	c.Set("ephemeral")
+	if !c.Has("ephemeral") {
+		t.Fatal("expected key to exist immediately after set")
+	}
+
+	time.Sleep(80 * time.Millisecond)
+
+	if c.Has("ephemeral") {
+		t.Error("expected key to have expired")
+	}
+}
+
+func TestTTLCache_MaxSize_EvictsOldest(t *testing.T) {
+	c := NewTTLCache(time.Hour, 3)
+	defer c.Stop()
+
+	c.Set("first")
+	time.Sleep(time.Millisecond)
+	c.Set("second")
+	time.Sleep(time.Millisecond)
+	c.Set("third")
+
+	if c.Len() != 3 {
+		t.Fatalf("expected len 3, got %d", c.Len())
+	}
+
+	// Adding a 4th should evict "first" (oldest)
+	c.Set("fourth")
+
+	if c.Len() != 3 {
+		t.Fatalf("expected len 3 after eviction, got %d", c.Len())
+	}
+	if c.Has("first") {
+		t.Error("expected 'first' to be evicted")
+	}
+	if !c.Has("second") {
+		t.Error("expected 'second' to survive")
+	}
+	if !c.Has("fourth") {
+		t.Error("expected 'fourth' to be present")
+	}
+}
+
+func TestTTLCache_ReaperCleansExpired(t *testing.T) {
+	// TTL=50ms, reaper runs every 25ms
+	c := NewTTLCache(50*time.Millisecond, 1000)
+	defer c.Stop()
+
+	for i := 0; i < 100; i++ {
+		c.Set(string(rune('a' + i)))
+	}
+	if c.Len() != 100 {
+		t.Fatalf("expected 100 entries, got %d", c.Len())
+	}
+
+	// Wait for expiry + multiple reaper cycles
+	time.Sleep(250 * time.Millisecond)
+
+	if c.Len() != 0 {
+		t.Errorf("expected 0 entries after reaper, got %d", c.Len())
+	}
+}
+
+func TestTTLCache_RefreshKeepsAlive(t *testing.T) {
+	c := NewTTLCache(80*time.Millisecond, 1000)
+	defer c.Stop()
+
+	c.Set("keep")
+	time.Sleep(50 * time.Millisecond)
+	// Refresh before expiry
+	c.Set("keep")
+	time.Sleep(50 * time.Millisecond)
+
+	if !c.Has("keep") {
+		t.Error("expected refreshed key to still be alive")
+	}
+}
+
+func TestTTLCache_ConcurrentAccess(t *testing.T) {
+	c := NewTTLCache(time.Hour, 100000)
+	defer c.Stop()
+
+	done := make(chan struct{})
+	// Hammer from multiple goroutines
+	for g := 0; g < 10; g++ {
+		go func(id int) {
+			for i := 0; i < 1000; i++ {
+				key := string(rune(id*1000 + i))
+				c.Set(key)
+				c.Has(key)
+			}
+			done <- struct{}{}
+		}(g)
+	}
+	for g := 0; g < 10; g++ {
+		<-done
+	}
+	// No race detector panic = pass
+}


### PR DESCRIPTION
Fixes #470

- Replace unbounded `seen` map with TTLCache (24h expiry, 50k max)
- Reduce concurrent article fetches 10 → 4
- Reduce article size limit 10MB → 2MB
- Stagger feed startup 1s → 5s per feed
- Tests for all new behavior (race-safe)