### PR TITLE
fix(scrib): add model field to STT request

### DIFF
--- a/scrib/client/client.go
+++ b/scrib/client/client.go
@@ -105,6 +105,7 @@ type TranscriptResult struct {
 // Transcribe runs STT on an audio file.
 func (c *Client) Transcribe(audioPath string) (*TranscriptResult, error) {
 	body, ct, err := c.multipartFile(audioPath, map[string]string{
+		"model":           "whisper-1",
 		"response_format": "verbose_json",
 	})
 	if err != nil {


### PR DESCRIPTION
mlx-audio requires model field in transcription requests.