### PR TITLE
fix(scrib): use configurable STT model name instead of whisper-1

### DIFF
--- a/scrib/client/client.go
+++ b/scrib/client/client.go
@@ -17,20 +17,25 @@ type Client struct {
 	AudioURL   string // mlx-audio server (default http://127.0.0.1:8000)
 	GatewayURL string // kgateway (default https://gateway.goyangi.io)
 	APIKey     string // optional Bearer token for authenticated endpoints
+	STTModel   string // STT model name (default mlx-community/parakeet-tdt-0.6b-v3)
 	HTTPClient *http.Client
 }
 
-func New(audioURL, gatewayURL, apiKey string) *Client {
+func New(audioURL, gatewayURL, apiKey, sttModel string) *Client {
 	if audioURL == "" {
 		audioURL = "http://127.0.0.1:8000"
 	}
 	if gatewayURL == "" {
 		gatewayURL = "https://gateway.goyangi.io"
 	}
+	if sttModel == "" {
+		sttModel = "mlx-community/parakeet-tdt-0.6b-v3"
+	}
 	return &Client{
 		AudioURL:   audioURL,
 		GatewayURL: gatewayURL,
 		APIKey:     apiKey,
+		STTModel:   sttModel,
 		HTTPClient: &http.Client{},
 	}
 }
@@ -105,7 +110,7 @@ type TranscriptResult struct {
 // Transcribe runs STT on an audio file.
 func (c *Client) Transcribe(audioPath string) (*TranscriptResult, error) {
 	body, ct, err := c.multipartFile(audioPath, map[string]string{
-		"model":           "whisper-1",
+		"model":           c.STTModel,
 		"response_format": "verbose_json",
 	})
 	if err != nil {

--- a/scrib/config/config.go
+++ b/scrib/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	GatewayURL    string          `toml:"gateway_url"`
 	AudioURL      string          `toml:"audio_url"`
 	APIKey        string          `toml:"api_key"`
+	STTModel      string          `toml:"stt_model"`
 	OutputDir     string          `toml:"output_dir"`
 	ObsidianVault string          `toml:"obsidian_vault"`
 	SampleRate    int             `toml:"sample_rate"`
@@ -41,6 +42,7 @@ func defaults() *Config {
 	return &Config{
 		GatewayURL:   "https://gateway.goyangi.io",
 		AudioURL:     "http://127.0.0.1:8000",
+		STTModel:     "mlx-community/parakeet-tdt-0.6b-v3",
 		OutputDir:    "~/meetings",
 		SampleRate:   16000,
 		Format:       "wav",

--- a/scrib/main.go
+++ b/scrib/main.go
@@ -191,7 +191,7 @@ func runRecord(cfg *config.Config, args []string, annotateAfter bool) error {
 }
 
 func runAnnotate(cfg *config.Config, audioPath string) error {
-	c := client.New(cfg.AudioURL, cfg.GatewayURL, cfg.APIKey)
+	c := client.New(cfg.AudioURL, cfg.GatewayURL, cfg.APIKey, cfg.STTModel)
 
 	fmt.Printf("Annotating %s...\n", audioPath)
 	fmt.Println("  → Running VAD + STT (concurrent)...")
@@ -430,7 +430,7 @@ func runTUI(cfg *config.Config, args []string) error {
 	}
 	outPath := filepath.Join(outDir, name+".wav")
 
-	c := client.New(cfg.AudioURL, cfg.GatewayURL, cfg.APIKey)
+	c := client.New(cfg.AudioURL, cfg.GatewayURL, cfg.APIKey, cfg.STTModel)
 
 	db, _ := openDB()
 	if db != nil {


### PR DESCRIPTION
whisper-1 is an OpenAI model name, not a HuggingFace repo. mlx-audio tries to download it and fails. Default to mlx-community/parakeet-tdt-0.6b-v3, configurable via stt_model in config.