### PR TITLE
fix(lake): remove double-nesting of _raw_payload in iceberg writer

### DIFF
--- a/lake/internal/iceberg/writer.go
+++ b/lake/internal/iceberg/writer.go
@@ -2,7 +2,6 @@ package iceberg
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -83,8 +82,7 @@ func (w *Writer) AppendBronze(ctx context.Context, tableName string, rows []map[
 	for i, row := range rows {
 		sources[i] = source
 		ingestedAt[i] = ts
-		payload, _ := json.Marshal(row)
-		payloads[i] = string(payload)
+		payloads[i] = row["_raw_payload"].(string)
 		batchIDs[i] = batchID
 	}
 
@@ -140,8 +138,7 @@ func (w *Writer) AppendSilver(ctx context.Context, tableName string, rows []map[
 	for i, row := range rows {
 		sources[i] = source
 		ingestedAt[i] = ts
-		payload, _ := json.Marshal(row)
-		payloads[i] = string(payload)
+		payloads[i] = row["_raw_payload"].(string)
 		batchIDs[i] = batchID
 	}
 


### PR DESCRIPTION
AppendBronze and AppendSilver were json.Marshal-ing the entire row map including the already-JSON _raw_payload string, causing double-encoding in iceberg tables.

Fix: extract _raw_payload directly as a string instead of re-marshaling. Removes unused encoding/json import.

Note: existing data in bronze tables is double-nested and will need a backfill/rewrite to fix historical records.