### PR TITLE
fix(lake): handle nil _raw_payload in AppendBronze/AppendSilver

### DIFF
--- a/lake/internal/iceberg/writer.go
+++ b/lake/internal/iceberg/writer.go
@@ -2,6 +2,7 @@ package iceberg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -82,7 +83,12 @@ func (w *Writer) AppendBronze(ctx context.Context, tableName string, rows []map[
 	for i, row := range rows {
 		sources[i] = source
 		ingestedAt[i] = ts
-		payloads[i] = row["_raw_payload"].(string)
+		if v, ok := row["_raw_payload"]; ok && v != nil {
+			payloads[i] = v.(string)
+		} else {
+			b, _ := json.Marshal(row)
+			payloads[i] = string(b)
+		}
 		batchIDs[i] = batchID
 	}
 
@@ -138,7 +144,12 @@ func (w *Writer) AppendSilver(ctx context.Context, tableName string, rows []map[
 	for i, row := range rows {
 		sources[i] = source
 		ingestedAt[i] = ts
-		payloads[i] = row["_raw_payload"].(string)
+		if v, ok := row["_raw_payload"]; ok && v != nil {
+			payloads[i] = v.(string)
+		} else {
+			b, _ := json.Marshal(row)
+			payloads[i] = string(b)
+		}
 		batchIDs[i] = batchID
 	}
 


### PR DESCRIPTION
lake-promote panics when processing old bronze parquet data where `_raw_payload` is nil:

```
panic: interface conversion: interface {} is nil, not string
  lake/internal/iceberg/writer.go:141
```

Fix: defensive nil check — if `_raw_payload` is nil or missing, fall back to `json.Marshal(row)` instead of panicking on type assertion.

Affects both `AppendBronze` and `AppendSilver` paths.