### PR TITLE
kobo: harden dash server/client; ship client via image

### DIFF
--- a/kobo/dash-server/BUILD.bazel
+++ b/kobo/dash-server/BUILD.bazel
@@ -25,23 +25,34 @@ go_binary(
 go_binary(
     name = "dash-server_linux_amd64",
     embed = [":lib"],
-    goos = "linux",
     goarch = "amd64",
+    goos = "linux",
     pure = "on",
     visibility = ["//visibility:public"],
 )
 
 pkg_tar(
-    name = "dash-server_layer",
+    name = "server_layer",
     srcs = [":dash-server_linux_amd64"],
-    strip_prefix = ".",
+    package_dir = "/app",
+    remap_paths = {"/dash-server_linux_amd64": "/dash-server"},
+)
+
+pkg_tar(
+    name = "kobo_dash_layer",
+    srcs = ["//kobo/kobo-dash:kobo-dash_linux_arm"],
+    package_dir = "/app",
+    remap_paths = {"/kobo-dash_linux_arm": "/kobo-dash"},
 )
 
 oci_image(
     name = "dash-server_image",
     base = "@distroless_static_linux_amd64",
-    entrypoint = ["/dash-server_linux_amd64_/dash-server_linux_amd64"],
-    tars = [":dash-server_layer"],
+    entrypoint = ["/app/dash-server"],
+    tars = [
+        ":server_layer",
+        ":kobo_dash_layer",
+    ],
 )
 
 oci_push(

--- a/kobo/dash-server/main.go
+++ b/kobo/dash-server/main.go
@@ -1,21 +1,27 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/fogleman/gg"
@@ -38,7 +44,7 @@ func init() {
 	flag.IntVar(&width, "width", envOrInt("DASH_WIDTH", 1072), "display width")
 	flag.IntVar(&height, "height", envOrInt("DASH_HEIGHT", 1448), "display height")
 	flag.StringVar(&mdFile, "file", envOr("DASH_FILE", "/data/dashboard.md"), "markdown file path")
-	flag.StringVar(&binDir, "bindir", envOr("DASH_BINDIR", "/data/bin/"), "directory containing kobo-dash binary")
+	flag.StringVar(&binDir, "bindir", envOr("DASH_BINDIR", "/app"), "directory containing kobo-dash binary")
 }
 
 func envOr(key, fallback string) string {
@@ -66,9 +72,10 @@ var (
 )
 
 var (
-	boldRe  = regexp.MustCompile(`\*\*(.+?)\*\*`)
-	emojiRe = regexp.MustCompile(`[\x{1F000}-\x{1FFFF}]|[\x{2600}-\x{27BF}]|[\x{FE00}-\x{FEFF}]|[\x{1F900}-\x{1F9FF}]|[\x{200D}\x{20E3}\x{FE0F}]`)
-	warnRe  = regexp.MustCompile(`\x{26A0}\x{FE0F}?`)
+	boldRe    = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	emojiRe   = regexp.MustCompile(`[\x{1F000}-\x{1FFFF}]|[\x{2600}-\x{27BF}]|[\x{FE00}-\x{FEFF}]|[\x{1F900}-\x{1F9FF}]|[\x{200D}\x{20E3}\x{FE0F}]`)
+	warnRe    = regexp.MustCompile(`\x{26A0}\x{FE0F}?`)
+	numListRe = regexp.MustCompile(`^(\d+)\.\s+(.*)$`)
 )
 
 func initFonts() {
@@ -106,12 +113,40 @@ func initFonts() {
 func main() {
 	flag.Parse()
 	initFonts()
-	http.HandleFunc("/dashboard.png", handleDashboard)
-	http.HandleFunc("/health", handleHealth)
-	http.HandleFunc("/kobo-dash.bin", handleBinary)
-	http.HandleFunc("/kobo-dash.sha256", handleBinarySHA256)
-	log.Printf("listening on %s (%dx%d) file=%s bindir=%s", addr, width, height, mdFile, binDir)
-	log.Fatal(http.ListenAndServe(addr, nil))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/dashboard.png", handleDashboard)
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/kobo-dash.bin", handleBinary)
+	mux.HandleFunc("/kobo-dash.sha256", handleBinarySHA256)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		log.Printf("listening on %s (%dx%d) file=%s bindir=%s", addr, width, height, mdFile, binDir)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("shutting down")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("shutdown: %v", err)
+	}
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -142,18 +177,32 @@ func computeBinHash() (string, error) {
 		return binHashCache, nil
 	}
 
-	data, err := os.ReadFile(binPath())
+	f, err := os.Open(binPath())
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 
-	h := sha256.Sum256(data)
-	binHashCache = hex.EncodeToString(h[:])
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	binHashCache = hex.EncodeToString(h.Sum(nil))
 	binHashModTime = info.ModTime()
 	return binHashCache, nil
 }
 
 func handleBinary(w http.ResponseWriter, r *http.Request) {
+	hash, err := computeBinHash()
+	if err == nil {
+		etag := `"` + hash + `"`
+		if match := r.Header.Get("If-None-Match"); match == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Cache-Control", "no-cache")
+	}
 	http.ServeFile(w, r, binPath())
 }
 
@@ -164,23 +213,89 @@ func handleBinarySHA256(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Cache-Control", "no-cache")
 	fmt.Fprintln(w, hash)
 }
 
-func handleDashboard(w http.ResponseWriter, r *http.Request) {
-	content, err := os.ReadFile(mdFile)
-	if err != nil {
-		log.Printf("read %s: %v", mdFile, err)
-		content = nil
+type dashCache struct {
+	mu      sync.Mutex
+	modTime time.Time
+	size    int64
+	png     []byte
+	etag    string
+}
+
+var dashboardCache dashCache
+
+func renderDashboard() ([]byte, string, error) {
+	dashboardCache.mu.Lock()
+	defer dashboardCache.mu.Unlock()
+
+	info, err := os.Stat(mdFile)
+	var modTime time.Time
+	var size int64
+	if err == nil {
+		modTime = info.ModTime()
+		size = info.Size()
+	}
+
+	if dashboardCache.png != nil &&
+		dashboardCache.modTime.Equal(modTime) &&
+		dashboardCache.size == size {
+		return dashboardCache.png, dashboardCache.etag, nil
+	}
+
+	var content []byte
+	if err == nil {
+		content, err = os.ReadFile(mdFile)
+		if err != nil {
+			log.Printf("read %s: %v", mdFile, err)
+			content = nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Printf("stat %s: %v", mdFile, err)
 	}
 
 	img := renderMarkdown(width, height, content)
 	gray := toGrayscale(img)
 	dithered := floydSteinberg(gray)
 
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, dithered); err != nil {
+		return nil, "", err
+	}
+
+	sum := sha256.Sum256(buf.Bytes())
+	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+
+	dashboardCache.png = buf.Bytes()
+	dashboardCache.etag = etag
+	dashboardCache.modTime = modTime
+	dashboardCache.size = size
+
+	return dashboardCache.png, etag, nil
+}
+
+func handleDashboard(w http.ResponseWriter, r *http.Request) {
+	data, etag, err := renderDashboard()
+	if err != nil {
+		log.Printf("render: %v", err)
+		http.Error(w, "render failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "no-cache")
+
+	if match := r.Header.Get("If-None-Match"); match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
 	w.Header().Set("Content-Type", "image/png")
-	if err := png.Encode(w, dithered); err != nil {
-		log.Printf("png encode: %v", err)
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	if _, err := w.Write(data); err != nil {
+		log.Printf("write response: %v", err)
 	}
 }
 
@@ -246,9 +361,11 @@ func renderMarkdown(w, h int, content []byte) image.Image {
 	contentW := float64(w) - 2*margin
 	lines := strings.Split(string(content), "\n")
 	firstSection := true
+	truncated := false
 
 	for _, line := range lines {
 		if y > float64(h)-40 {
+			truncated = true
 			break
 		}
 
@@ -299,19 +416,19 @@ func renderMarkdown(w, h int, content []byte) image.Image {
 			drawSpans(dc, spans, margin+bw, y)
 			y += 35
 
-		case len(trimmed) > 0 && trimmed[0] >= '0' && trimmed[0] <= '9' && strings.Contains(trimmed, ". "):
-			idx := strings.Index(trimmed, ". ")
-			num := trimmed[:idx+1]
-			text := trimmed[idx+2:]
-			spans := parseInline(text)
-			dc.SetFontFace(bodyFace)
-			dc.SetColor(color.Black)
-			dc.DrawString(num+" ", margin, y)
-			nw, _ := dc.MeasureString(num + " ")
-			drawSpans(dc, spans, margin+nw, y)
-			y += 35
-
 		default:
+			if m := numListRe.FindStringSubmatch(trimmed); m != nil {
+				num := m[1] + "."
+				text := m[2]
+				spans := parseInline(text)
+				dc.SetFontFace(bodyFace)
+				dc.SetColor(color.Black)
+				dc.DrawString(num+" ", margin, y)
+				nw, _ := dc.MeasureString(num + " ")
+				drawSpans(dc, spans, margin+nw, y)
+				y += 35
+				continue
+			}
 			spans := parseInline(trimmed)
 			dc.SetColor(color.Black)
 			drawSpans(dc, spans, margin, y)
@@ -319,11 +436,20 @@ func renderMarkdown(w, h int, content []byte) image.Image {
 		}
 	}
 
+	if truncated {
+		dc.SetFontFace(bodyFace)
+		dc.SetColor(color.Gray{Y: 100})
+		dc.DrawStringAnchored("\u2026", float64(w)/2, float64(h)-20, 0.5, 0.5)
+	}
+
 	return dc.Image()
 }
 
 func toGrayscale(img image.Image) *image.Gray {
 	bounds := img.Bounds()
+	if g, ok := img.(*image.Gray); ok {
+		return g
+	}
 	gray := image.NewGray(bounds)
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
@@ -338,35 +464,29 @@ func floydSteinberg(gray *image.Gray) *image.Gray {
 	w := bounds.Dx()
 	h := bounds.Dy()
 
-	errors := make([][]float64, h)
-	for i := range errors {
-		errors[i] = make([]float64, w)
-	}
+	curr := make([]int32, w+2)
+	next := make([]int32, w+2)
 
 	out := image.NewGray(bounds)
 
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
-			oldVal := float64(gray.GrayAt(x+bounds.Min.X, y+bounds.Min.Y).Y) + errors[y][x]
-			var newVal float64
+			oldVal := int32(gray.Pix[y*gray.Stride+x]) + curr[x+1]
+			var newVal int32
 			if oldVal > 127 {
 				newVal = 255
 			}
-			out.SetGray(x+bounds.Min.X, y+bounds.Min.Y, color.Gray{Y: uint8(newVal)})
+			out.Pix[y*out.Stride+x] = uint8(newVal)
 
-			err := oldVal - newVal
-			if x+1 < w {
-				errors[y][x+1] += err * 7 / 16
-			}
-			if y+1 < h {
-				if x-1 >= 0 {
-					errors[y+1][x-1] += err * 3 / 16
-				}
-				errors[y+1][x] += err * 5 / 16
-				if x+1 < w {
-					errors[y+1][x+1] += err * 1 / 16
-				}
-			}
+			qerr := oldVal - newVal
+			curr[x+2] += qerr * 7 / 16
+			next[x] += qerr * 3 / 16
+			next[x+1] += qerr * 5 / 16
+			next[x+2] += qerr * 1 / 16
+		}
+		curr, next = next, curr
+		for i := range next {
+			next[i] = 0
 		}
 	}
 	return out

--- a/kobo/kobo-dash/main.go
+++ b/kobo/kobo-dash/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"image"
 	"image/color"
 	"image/png"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -23,8 +25,58 @@ import (
 )
 
 const (
+	fbioGetVScreenInfo = 0x4600
+	fbioGetFScreenInfo = 0x4602
+
 	mxcfbSendUpdate = 0x4048462e
 )
+
+type fbBitfield struct {
+	offset   uint32
+	length   uint32
+	msbRight uint32
+}
+
+type fbVarScreenInfo struct {
+	xres, yres                 uint32
+	xresVirtual, yresVirtual   uint32
+	xoffset, yoffset           uint32
+	bitsPerPixel               uint32
+	grayscale                  uint32
+	red, green, blue, transp   fbBitfield
+	nonstd                     uint32
+	activate                   uint32
+	height, width              uint32
+	accelFlags                 uint32
+	pixclock                   uint32
+	leftMargin, rightMargin    uint32
+	upperMargin, lowerMargin   uint32
+	hsyncLen, vsyncLen         uint32
+	sync                       uint32
+	vmode                      uint32
+	rotate                     uint32
+	colorspace                 uint32
+	reserved                   [4]uint32
+}
+
+type fbFixScreenInfo struct {
+	id           [16]byte
+	smemStart    uint64
+	smemLen      uint32
+	fbType       uint32
+	typeAux      uint32
+	visual       uint32
+	xpanstep     uint16
+	ypanstep     uint16
+	ywrapstep    uint16
+	_pad         uint16
+	lineLength   uint32
+	mmioStart    uint64
+	mmioLen      uint32
+	accel        uint32
+	capabilities uint16
+	reserved     [2]uint16
+}
 
 type mxcfbUpdateData struct {
 	top          uint32
@@ -42,10 +94,19 @@ type mxcfbUpdateData struct {
 }
 
 var (
-	serverURL string
-	interval  time.Duration
-	fbDev     string
-	noUpdate  bool
+	serverURL  string
+	interval   time.Duration
+	fbDev      string
+	noUpdate   bool
+	logFile    string
+	probeMode  bool
+	testMode   bool
+	httpClient = &http.Client{Timeout: 30 * time.Second}
+)
+
+var (
+	lastDashETag   string
+	updateMarkerID uint32 = 1
 )
 
 func init() {
@@ -53,6 +114,9 @@ func init() {
 	flag.DurationVar(&interval, "interval", envOrDuration("DASH_INTERVAL", time.Hour), "refresh interval")
 	flag.StringVar(&fbDev, "fb", envOr("DASH_FB", "/dev/fb0"), "framebuffer device")
 	flag.BoolVar(&noUpdate, "no-update", false, "disable self-update")
+	flag.StringVar(&logFile, "log", envOr("DASH_LOG", "/mnt/onboard/.adds/kobo-dash/kobo-dash.log"), "log file path (empty to disable)")
+	flag.BoolVar(&probeMode, "probe", false, "probe framebuffer and exit")
+	flag.BoolVar(&testMode, "test", false, "write test gradient to framebuffer and exit")
 }
 
 func envOr(key, fallback string) string {
@@ -71,13 +135,57 @@ func envOrDuration(key string, fallback time.Duration) time.Duration {
 	return fallback
 }
 
+func setupLogging() func() {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	if logFile == "" {
+		return func() {}
+	}
+	if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {
+		log.Printf("log mkdir: %v", err)
+		return func() {}
+	}
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Printf("log open %s: %v", logFile, err)
+		return func() {}
+	}
+	log.SetOutput(io.MultiWriter(os.Stderr, f))
+	return func() { f.Close() }
+}
+
 func main() {
 	flag.Parse()
+	closeLog := setupLogging()
+	defer closeLog()
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("PANIC: %v\n%s", r, debug.Stack())
+			os.Exit(2)
+		}
+	}()
+
+	log.Printf("kobo-dash start: url=%s interval=%s fb=%s no-update=%v probe=%v test=%v",
+		serverURL, interval, fbDev, noUpdate, probeMode, testMode)
+
+	if probeMode {
+		if err := probe(); err != nil {
+			log.Printf("probe error: %v", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if testMode {
+		if err := runTest(); err != nil {
+			log.Printf("test error: %v", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
-
-	log.Printf("kobo-dash: url=%s interval=%s fb=%s no-update=%v", serverURL, interval, fbDev, noUpdate)
 
 	for {
 		if err := refresh(ctx); err != nil {
@@ -93,11 +201,142 @@ func main() {
 	}
 }
 
+func probe() error {
+	fb, err := os.OpenFile(fbDev, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", fbDev, err)
+	}
+	defer fb.Close()
+
+	var vinfo fbVarScreenInfo
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fb.Fd(),
+		fbioGetVScreenInfo, uintptr(unsafe.Pointer(&vinfo))); errno != 0 {
+		return fmt.Errorf("FBIOGET_VSCREENINFO: %w", errno)
+	}
+
+	var finfo fbFixScreenInfo
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fb.Fd(),
+		fbioGetFScreenInfo, uintptr(unsafe.Pointer(&finfo))); errno != 0 {
+		return fmt.Errorf("FBIOGET_FSCREENINFO: %w", errno)
+	}
+
+	id := string(bytes.TrimRight(finfo.id[:], "\x00"))
+	log.Printf("fb id:            %q", id)
+	log.Printf("fb resolution:    %dx%d (virtual %dx%d)",
+		vinfo.xres, vinfo.yres, vinfo.xresVirtual, vinfo.yresVirtual)
+	log.Printf("fb bits/pixel:    %d", vinfo.bitsPerPixel)
+	log.Printf("fb grayscale:     %d", vinfo.grayscale)
+	log.Printf("fb rotate:        %d", vinfo.rotate)
+	log.Printf("fb line_length:   %d", finfo.lineLength)
+	log.Printf("fb smem_len:      %d", finfo.smemLen)
+	log.Printf("fb red:           offset=%d length=%d", vinfo.red.offset, vinfo.red.length)
+	log.Printf("fb green:         offset=%d length=%d", vinfo.green.offset, vinfo.green.length)
+	log.Printf("fb blue:          offset=%d length=%d", vinfo.blue.offset, vinfo.blue.length)
+
+	expected := vinfo.yres * finfo.lineLength
+	log.Printf("fb expected write size: %d bytes (yres * line_length)", expected)
+
+	return nil
+}
+
+type fbInfo struct {
+	xres, yres   int
+	bpp          int
+	lineLength   int
+	grayscale    uint32
+	redOff, redLen uint32
+	id           string
+}
+
+func readFBInfo(fb *os.File) (fbInfo, error) {
+	var vinfo fbVarScreenInfo
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fb.Fd(),
+		fbioGetVScreenInfo, uintptr(unsafe.Pointer(&vinfo))); errno != 0 {
+		return fbInfo{}, fmt.Errorf("FBIOGET_VSCREENINFO: %w", errno)
+	}
+	var finfo fbFixScreenInfo
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fb.Fd(),
+		fbioGetFScreenInfo, uintptr(unsafe.Pointer(&finfo))); errno != 0 {
+		return fbInfo{}, fmt.Errorf("FBIOGET_FSCREENINFO: %w", errno)
+	}
+	return fbInfo{
+		xres:       int(vinfo.xres),
+		yres:       int(vinfo.yres),
+		bpp:        int(vinfo.bitsPerPixel),
+		lineLength: int(finfo.lineLength),
+		grayscale:  vinfo.grayscale,
+		redOff:     vinfo.red.offset,
+		redLen:     vinfo.red.length,
+		id:         string(bytes.TrimRight(finfo.id[:], "\x00")),
+	}, nil
+}
+
+func runTest() error {
+	fb, err := os.OpenFile(fbDev, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer fb.Close()
+
+	info, err := readFBInfo(fb)
+	if err != nil {
+		return err
+	}
+	log.Printf("test: fb %s %dx%d bpp=%d stride=%d",
+		info.id, info.xres, info.yres, info.bpp, info.lineLength)
+
+	buf := make([]byte, info.yres*info.lineLength)
+	for y := 0; y < info.yres; y++ {
+		gray := uint8((y * 255) / info.yres)
+		row := buf[y*info.lineLength : y*info.lineLength+info.lineLength]
+		packRow(row, gray, info)
+	}
+	if _, err := fb.WriteAt(buf, 0); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	log.Printf("test: wrote gradient (%d bytes)", len(buf))
+
+	if err := triggerRefresh(fb); err != nil {
+		log.Printf("test: refresh ioctl failed: %v (screen may still update on next native refresh)", err)
+	} else {
+		log.Printf("test: refresh ioctl ok")
+	}
+	return nil
+}
+
+func packRow(row []byte, gray uint8, info fbInfo) {
+	switch info.bpp {
+	case 8:
+		for i := range row {
+			row[i] = gray
+		}
+	case 16:
+		// rgb565
+		r5 := uint16(gray>>3) & 0x1f
+		g6 := uint16(gray>>2) & 0x3f
+		b5 := uint16(gray>>3) & 0x1f
+		px := (r5 << 11) | (g6 << 5) | b5
+		for i := 0; i+1 < len(row); i += 2 {
+			row[i] = byte(px)
+			row[i+1] = byte(px >> 8)
+		}
+	case 32:
+		for i := 0; i+3 < len(row); i += 4 {
+			row[i+0] = gray
+			row[i+1] = gray
+			row[i+2] = gray
+			row[i+3] = 0xff
+		}
+	}
+}
+
 func refresh(ctx context.Context) error {
 	wifiOn()
 	defer wifiOff()
 
-	time.Sleep(2 * time.Second)
+	if err := waitForNetwork(ctx, 20*time.Second); err != nil {
+		return fmt.Errorf("wifi: %w", err)
+	}
 
 	if !noUpdate {
 		if err := checkUpdate(ctx); err != nil {
@@ -105,20 +344,56 @@ func refresh(ctx context.Context) error {
 		}
 	}
 
-	data, err := fetchPNG(ctx)
+	data, etag, notModified, err := fetchDashboard(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch: %w", err)
 	}
+	if notModified {
+		log.Printf("dashboard unchanged (etag=%s)", truncate(etag, 12))
+		return nil
+	}
 
-	if err := writeFramebuffer(data); err != nil {
+	if err := writeDashboard(data); err != nil {
 		return fmt.Errorf("fb write: %w", err)
 	}
 
-	if err := triggerRefresh(); err != nil {
-		return fmt.Errorf("refresh: %w", err)
-	}
-
+	lastDashETag = etag
 	return nil
+}
+
+func waitForNetwork(ctx context.Context, max time.Duration) error {
+	deadline := time.Now().Add(max)
+	url := serverURL + "/health"
+	for {
+		reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+		resp, err := httpClient.Do(req)
+		cancel()
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("health check failed after %s", max)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 func checkUpdate(ctx context.Context) error {
@@ -146,7 +421,7 @@ func checkUpdate(ctx context.Context) error {
 		return nil
 	}
 
-	log.Printf("update available: local=%s remote=%s", localHash[:12], remoteHash[:12])
+	log.Printf("update available: local=%s remote=%s", truncate(localHash, 12), truncate(remoteHash, 12))
 
 	binData, err := fetchBytes(ctx, serverURL+"/kobo-dash.bin")
 	if err != nil {
@@ -156,7 +431,7 @@ func checkUpdate(ctx context.Context) error {
 	h := sha256.Sum256(binData)
 	dlHash := hex.EncodeToString(h[:])
 	if dlHash != remoteHash {
-		return fmt.Errorf("hash mismatch: expected %s got %s", remoteHash[:12], dlHash[:12])
+		return fmt.Errorf("hash mismatch: expected %s got %s", truncate(remoteHash, 12), truncate(dlHash, 12))
 	}
 
 	tmpPath := selfPath + ".tmp"
@@ -174,12 +449,16 @@ func checkUpdate(ctx context.Context) error {
 }
 
 func hashFile(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:]), nil
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func fetchText(ctx context.Context, url string) (string, error) {
@@ -195,7 +474,7 @@ func fetchBytes(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -206,48 +485,142 @@ func fetchBytes(ctx context.Context, url string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-func fetchPNG(ctx context.Context) ([]byte, error) {
-	return fetchBytes(ctx, serverURL+"/dashboard.png")
+func fetchDashboard(ctx context.Context) ([]byte, string, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/dashboard.png", nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if lastDashETag != "" {
+		req.Header.Set("If-None-Match", lastDashETag)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer resp.Body.Close()
+
+	etag := resp.Header.Get("ETag")
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return nil, etag, true, nil
+	case http.StatusOK:
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", false, err
+		}
+		return data, etag, false, nil
+	default:
+		return nil, "", false, fmt.Errorf("status %d", resp.StatusCode)
+	}
 }
 
-func writeFramebuffer(data []byte) error {
+func writeDashboard(data []byte) error {
 	img, err := png.Decode(bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("png decode: %w", err)
 	}
 
-	bounds := img.Bounds()
-	w := bounds.Dx()
-	h := bounds.Dy()
-	pixels := make([]byte, w*h)
-
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			r, g, b, _ := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
-			gray := color.GrayModel.Convert(color.NRGBA{
-				R: uint8(r >> 8),
-				G: uint8(g >> 8),
-				B: uint8(b >> 8),
-				A: 255,
-			}).(color.Gray)
-			pixels[y*w+x] = gray.Y
-		}
-	}
-
-	return os.WriteFile(fbDev, pixels, 0644)
-}
-
-func triggerRefresh() error {
 	fb, err := os.OpenFile(fbDev, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open fb: %w", err)
+	}
+	defer fb.Close()
+
+	info, err := readFBInfo(fb)
 	if err != nil {
 		return err
 	}
-	defer fb.Close()
+
+	gray := toGray(img)
+	bounds := gray.Bounds()
+	imgW := bounds.Dx()
+	imgH := bounds.Dy()
+
+	if imgW != info.xres || imgH != info.yres {
+		log.Printf("warn: image %dx%d != fb %dx%d", imgW, imgH, info.xres, info.yres)
+	}
+
+	buf := make([]byte, info.yres*info.lineLength)
+	h := imgH
+	if h > info.yres {
+		h = info.yres
+	}
+	w := imgW
+	if w > info.xres {
+		w = info.xres
+	}
+
+	for y := 0; y < h; y++ {
+		row := buf[y*info.lineLength : y*info.lineLength+info.lineLength]
+		srcRow := gray.Pix[y*gray.Stride : y*gray.Stride+w]
+		packGrayRow(row, srcRow, info)
+	}
+
+	if _, err := fb.WriteAt(buf, 0); err != nil {
+		return fmt.Errorf("fb write: %w", err)
+	}
+
+	if err := triggerRefresh(fb); err != nil {
+		log.Printf("refresh ioctl failed: %v", err)
+	}
+	return nil
+}
+
+func toGray(img image.Image) *image.Gray {
+	if g, ok := img.(*image.Gray); ok {
+		return g
+	}
+	b := img.Bounds()
+	g := image.NewGray(b)
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			g.Set(x, y, img.At(x, y))
+		}
+	}
+	return g
+}
+
+func packGrayRow(dst, src []byte, info fbInfo) {
+	switch info.bpp {
+	case 8:
+		copy(dst, src)
+	case 16:
+		for x := 0; x < len(src) && (x*2+1) < len(dst); x++ {
+			v := src[x]
+			r5 := uint16(v>>3) & 0x1f
+			g6 := uint16(v>>2) & 0x3f
+			b5 := uint16(v>>3) & 0x1f
+			px := (r5 << 11) | (g6 << 5) | b5
+			dst[x*2] = byte(px)
+			dst[x*2+1] = byte(px >> 8)
+		}
+	case 32:
+		for x := 0; x < len(src) && (x*4+3) < len(dst); x++ {
+			v := src[x]
+			dst[x*4+0] = v
+			dst[x*4+1] = v
+			dst[x*4+2] = v
+			dst[x*4+3] = 0xff
+		}
+	default:
+		// fallback: best-effort write raw bytes
+		n := copy(dst, src)
+		_ = n
+	}
+	_ = color.Gray{}
+}
+
+func triggerRefresh(fb *os.File) error {
+	updateMarkerID++
+	if updateMarkerID == 0 {
+		updateMarkerID = 1
+	}
 
 	update := mxcfbUpdateData{
 		waveformMode: 2, // GC16
 		updateMode:   1, // full
-		updateMarker: 1,
+		updateMarker: updateMarkerID,
 		temp:         0x1001, // TEMP_USE_AMBIENT
 	}
 
@@ -264,9 +637,13 @@ func triggerRefresh() error {
 }
 
 func wifiOn() {
-	exec.Command("/usr/bin/wifi", "on").Run()
+	if err := exec.Command("/usr/bin/wifi", "on").Run(); err != nil {
+		log.Printf("wifi on: %v", err)
+	}
 }
 
 func wifiOff() {
-	exec.Command("/usr/bin/wifi", "off").Run()
+	if err := exec.Command("/usr/bin/wifi", "off").Run(); err != nil {
+		log.Printf("wifi off: %v", err)
+	}
 }

--- a/kobo/nickelmenu.cfg
+++ b/kobo/nickelmenu.cfg
@@ -1,8 +1,35 @@
 # kobo-dash NickelMenu config
 # Place at: /mnt/onboard/.adds/nm/kobo-dash.cfg
+#
+# Binary:  /mnt/onboard/.adds/kobo-dash/kobo-dash
+# Log:     /mnt/onboard/.adds/kobo-dash/kobo-dash.log
+# PID:     /mnt/onboard/.adds/kobo-dash/kobo-dash.pid
 
-menu_item :main :Start KoboDash :cmd_spawn :quiet:/mnt/onboard/.adds/kobo-dash/kobo-dash &
+menu_item :main :KoboDash: Start :cmd_spawn :quiet:
+  /mnt/onboard/.adds/kobo-dash/kobo-dash >> /mnt/onboard/.adds/kobo-dash/kobo-dash.log 2>&1 &
+  echo $! > /mnt/onboard/.adds/kobo-dash/kobo-dash.pid
   chain_success :dbg_toast :KoboDash started
 
-menu_item :main :Stop KoboDash :cmd_spawn :quiet:killall kobo-dash 2>/dev/null || true
+menu_item :main :KoboDash: Stop :cmd_spawn :quiet:
+  if [ -f /mnt/onboard/.adds/kobo-dash/kobo-dash.pid ]; then
+    kill $(cat /mnt/onboard/.adds/kobo-dash/kobo-dash.pid) 2>/dev/null;
+    rm -f /mnt/onboard/.adds/kobo-dash/kobo-dash.pid;
+  else
+    killall kobo-dash 2>/dev/null || true;
+  fi
   chain_success :dbg_toast :KoboDash stopped
+
+menu_item :main :KoboDash: Probe framebuffer :cmd_spawn :quiet:
+  /mnt/onboard/.adds/kobo-dash/kobo-dash -probe >> /mnt/onboard/.adds/kobo-dash/kobo-dash.log 2>&1
+  chain_success :dbg_toast :Probe written to log
+
+menu_item :main :KoboDash: Test gradient :cmd_spawn :quiet:
+  /mnt/onboard/.adds/kobo-dash/kobo-dash -test >> /mnt/onboard/.adds/kobo-dash/kobo-dash.log 2>&1
+  chain_success :dbg_toast :Test gradient sent
+
+menu_item :main :KoboDash: Tail log :cmd_output :500:sh:
+  tail -n 60 /mnt/onboard/.adds/kobo-dash/kobo-dash.log 2>&1 || echo "no log yet"
+
+menu_item :main :KoboDash: Clear log :cmd_spawn :quiet:
+  : > /mnt/onboard/.adds/kobo-dash/kobo-dash.log
+  chain_success :dbg_toast :Log cleared


### PR DESCRIPTION
## Summary
- Harden the kobo dash server and client: render caching with ETag/304, http timeouts, graceful shutdown, conditional GETs, fast framebuffer writes, probe/test flags, rotating log, and richer NickelMenu entries.
- Ship the `kobo-dash` linux/arm client inside the `dash-server` OCI image at `/app/kobo-dash` so the gateway-fronted pod can serve the client update bundle itself.
- Bump `rules_uv` to `0.89.2` (0.89.0/0.89.1 are missing from BCR) to unblock module resolution.

## Test plan
- `bazelisk build //kobo/...` — builds `dash-server`, `kobo-dash`, the linux/amd64 server binary, the linux/arm client binary, and the OCI image with both layers.
- `go vet` clean on both modules; `CGO_ENABLED=0 GOOS=linux GOARCH=arm go build` cross-compiles the client.