### PR TITLE
feat(scrib-audio): chunked diarization with embedding-based stitching

### DIFF
--- a/scrib-audio/BUILD.bazel
+++ b/scrib-audio/BUILD.bazel
@@ -55,3 +55,26 @@ py_test(
     args = ["-v"],
     target_compatible_with = ["@platforms//os:macos"],
 )
+
+py_test(
+    name = "test_align_golden",
+    srcs = ["tests/test_align_golden.py"],
+    data = ["tests/fixtures/align_golden.json"],
+    deps = [
+        ":scrib_audio_lib",
+        "@scrib_audio_pypi//pytest",
+    ],
+    args = ["-v"],
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+py_test(
+    name = "test_diarize_stitch",
+    srcs = ["tests/test_diarize_stitch.py"],
+    deps = [
+        ":scrib_audio_lib",
+        "@scrib_audio_pypi//pytest",
+    ],
+    args = ["-v"],
+    target_compatible_with = ["@platforms//os:macos"],
+)

--- a/scrib-audio/src/scrib_audio/diarize.py
+++ b/scrib-audio/src/scrib_audio/diarize.py
@@ -2,6 +2,13 @@
 
 Uses Senko (CAM++ embeddings + spectral/HDBSCAN clustering) with
 CoreML acceleration on Apple Silicon. Processes 1 hour in ~8 seconds.
+
+Long recordings (>~10min) are split into overlapping windows so no
+single Senko invocation exceeds Metal's per-buffer ceiling. Per-chunk
+speaker labels are stitched back together using the CAM++ embeddings
+Senko emits per speaker; two chunks' local ``SPEAKER_0``s collapse to
+one global label when their embedding cosine exceeds the merge
+threshold.
 """
 
 import logging
@@ -16,6 +23,20 @@ import soundfile as sf
 log = logging.getLogger(__name__)
 
 _diarizer = None
+
+# Chunking knobs. An hour of 16kHz float32 is ~230 MB of array; Senko's
+# CAM++ embeddings + spectral clustering expand that into buffers that
+# cross the ~9.5 GB per-buffer Metal ceiling well before the full file
+# fits. 600s chunks stay safely under the ceiling on an M4 Mini; 30s
+# overlap gives re-clustering a shared window to match speakers across
+# chunk seams.
+_DIAR_CHUNK_SECS = float(os.environ.get("SCRIB_AUDIO_DIAR_CHUNK_SECS", 600.0))
+_DIAR_OVERLAP_SECS = float(os.environ.get("SCRIB_AUDIO_DIAR_OVERLAP_SECS", 30.0))
+# Speakers within the same recording, same mic, same ambient profile
+# tend to score high on cosine similarity. 0.70 is looser than the
+# 0.75 the Go matcher uses cross-meeting because within-meeting we
+# want to merge aggressively.
+_DIAR_MERGE_SIM = float(os.environ.get("SCRIB_AUDIO_DIAR_MERGE_SIM", 0.70))
 
 
 @dataclass
@@ -162,6 +183,202 @@ def diarize(
         data = librosa.resample(data, orig_sr=sr, target_sr=16000)
         sr = 16000
     return diarize_array(data, sr, threshold, min_duration, merge_gap)
+
+
+def diarize_chunked(
+    data: np.ndarray,
+    sr: int,
+    threshold: float = 0.5,
+    min_duration: float = 0.0,
+    merge_gap: float = 0.0,
+    chunk_secs: float | None = None,
+    overlap_secs: float | None = None,
+    progress: callable = None,
+) -> DiarResult:
+    """Run diarization on a long in-memory array by splitting into windows.
+
+    Each window is diarised independently, then the per-chunk ``DiarResult``s
+    are stitched into a single coherent result using the CAM++ embeddings
+    Senko emits per local speaker.
+
+    If the full array fits in one chunk we short-circuit to
+    :func:`diarize_array` to avoid a pointless stitch pass.
+    """
+    if sr != 16000:
+        raise ValueError(f"diarize_chunked expects 16kHz, got {sr}")
+    if data.ndim != 1:
+        raise ValueError(f"diarize_chunked expects mono, got shape {data.shape}")
+
+    chunk_secs = chunk_secs if chunk_secs is not None else _DIAR_CHUNK_SECS
+    overlap_secs = overlap_secs if overlap_secs is not None else _DIAR_OVERLAP_SECS
+
+    duration = len(data) / sr
+    if duration <= chunk_secs:
+        return diarize_array(data, sr, threshold, min_duration, merge_gap)
+
+    def _emit(detail: str):
+        if progress is not None:
+            try:
+                progress("diarize_chunk", detail)
+            except Exception:
+                log.exception("progress callback raised")
+
+    chunk_len = int(chunk_secs * sr)
+    step = int((chunk_secs - overlap_secs) * sr)
+    if step <= 0:
+        raise ValueError("diarize_chunked: overlap must be less than chunk")
+
+    chunks: list[DiarResult] = []
+    offsets: list[float] = []
+    start = 0
+    index = 0
+    total = max(1, (len(data) - chunk_len) // step + 1 + 1)
+    while start < len(data):
+        end = min(start + chunk_len, len(data))
+        window = data[start:end]
+        offset_secs = start / sr
+        log.info(
+            "diarize_chunked: chunk %d/%d offset=%.1fs len=%.1fs",
+            index + 1, total, offset_secs, (end - start) / sr,
+        )
+        _emit(f"chunk {index + 1}/{total} @ {offset_secs:.0f}s")
+        chunk = diarize_array(window, sr, threshold, min_duration, merge_gap)
+        chunks.append(chunk)
+        offsets.append(offset_secs)
+        index += 1
+        if end >= len(data):
+            break
+        start += step
+
+    return _stitch_chunks(chunks, offsets, duration, merge_gap=merge_gap)
+
+
+def _stitch_chunks(
+    chunks: list["DiarResult"],
+    offsets: list[float],
+    total_duration: float,
+    merge_gap: float = 0.5,
+    sim_threshold: float | None = None,
+) -> "DiarResult":
+    """Stitch per-chunk DiarResults into a single coherent result.
+
+    Pure function, no Senko dependency — makes unit testing trivial.
+
+    For each chunk:
+      1. Translate segment times into the global timeline.
+      2. For each local speaker, match against the running global pool
+         by cosine similarity against the pool's running-mean embedding.
+      3. If best match >= sim_threshold, reuse that global label and
+         blend the embedding (running average). Otherwise allocate a
+         new global label.
+      4. Rewrite the chunk's segments with the global label.
+    Finally dedupe overlapping segments (same speaker, overlapping in
+    time) and merge adjacent-same-speaker gaps via ``_merge_segments``.
+    """
+    if not chunks:
+        return DiarResult(segments=[], num_speakers=0, duration_seconds=0.0)
+    if len(chunks) == 1:
+        only = chunks[0]
+        return DiarResult(
+            segments=only.segments,
+            num_speakers=only.num_speakers,
+            duration_seconds=total_duration,
+            speaker_embeddings=only.speaker_embeddings,
+        )
+
+    sim_threshold = sim_threshold if sim_threshold is not None else _DIAR_MERGE_SIM
+
+    # Global state: next label id, per-global embedding running mean,
+    # and a count to weight the mean.
+    next_id = 0
+    global_emb: dict[str, np.ndarray] = {}
+    global_count: dict[str, int] = {}
+    out_segments: list[DiarSegment] = []
+
+    def _alloc() -> str:
+        nonlocal next_id
+        label = f"SPEAKER_{next_id}"
+        next_id += 1
+        return label
+
+    for chunk, offset in zip(chunks, offsets):
+        # local → global label map, resolved per chunk.
+        local_to_global: dict[str, str] = {}
+        for local_label, emb in chunk.speaker_embeddings.items():
+            e = np.asarray(emb, dtype=np.float32)
+            n = np.linalg.norm(e)
+            if n > 0:
+                e = e / n
+
+            best_label: str | None = None
+            best_sim = -1.0
+            for g_label, g_emb in global_emb.items():
+                sim = float(np.dot(e, g_emb))
+                if sim > best_sim:
+                    best_sim = sim
+                    best_label = g_label
+
+            if best_label is not None and best_sim >= sim_threshold:
+                # Blend into running mean.
+                count = global_count[best_label]
+                blended = (global_emb[best_label] * count + e) / (count + 1)
+                norm = np.linalg.norm(blended)
+                if norm > 0:
+                    blended = blended / norm
+                global_emb[best_label] = blended
+                global_count[best_label] = count + 1
+                local_to_global[local_label] = best_label
+            else:
+                new_label = _alloc()
+                global_emb[new_label] = e
+                global_count[new_label] = 1
+                local_to_global[local_label] = new_label
+
+        # Local speakers with no embedding get their own isolated labels
+        # so they don't all collapse onto the same UNKNOWN.
+        for seg in chunk.segments:
+            if seg.speaker in local_to_global:
+                gs = local_to_global[seg.speaker]
+            else:
+                gs = _alloc()
+                local_to_global[seg.speaker] = gs
+            out_segments.append(DiarSegment(
+                speaker=gs,
+                start=round(seg.start + offset, 3),
+                end=round(seg.end + offset, 3),
+            ))
+
+    out_segments = _dedupe_overlap(out_segments)
+    if merge_gap > 0:
+        out_segments = _merge_segments(out_segments, merge_gap)
+
+    return DiarResult(
+        segments=out_segments,
+        num_speakers=len(global_emb) or len({s.speaker for s in out_segments}),
+        duration_seconds=round(total_duration, 3),
+        speaker_embeddings={k: v.astype(np.float32).tolist() for k, v in global_emb.items()},
+    )
+
+
+def _dedupe_overlap(segments: list[DiarSegment]) -> list[DiarSegment]:
+    """Collapse overlapping same-speaker segments that arise from chunk overlap.
+
+    Two chunks' overlap region can emit near-duplicate segments once
+    labels are unified. We sort by (start, end) and fold any segment
+    that starts inside the previous one (same speaker) into the running
+    end.
+    """
+    if not segments:
+        return []
+    segments.sort(key=lambda s: (s.start, s.end))
+    out = [segments[0]]
+    for seg in segments[1:]:
+        prev = out[-1]
+        if seg.speaker == prev.speaker and seg.start <= prev.end:
+            prev.end = max(prev.end, seg.end)
+        else:
+            out.append(seg)
+    return out
 
 
 def _merge_segments(

--- a/scrib-audio/src/scrib_audio/pipeline.py
+++ b/scrib-audio/src/scrib_audio/pipeline.py
@@ -11,7 +11,7 @@ import numpy as np
 import soundfile as sf
 
 from .align import AlignedSegment, align
-from .diarize import diarize_array
+from .diarize import diarize_chunked
 from .transcribe import Transcript, transcribe_array
 
 log = logging.getLogger(__name__)
@@ -75,11 +75,12 @@ def process(
     log.info("pipeline: %.0fs audio, %d samples", duration, len(data))
 
     _emit("diarize", f"{duration:.0f}s audio")
-    diar_result = diarize_array(
+    diar_result = diarize_chunked(
         data, sr,
         threshold=threshold,
         min_duration=min_duration,
         merge_gap=merge_gap,
+        progress=progress,
     )
     log.info(
         "pipeline: diarization done — %d segments, %d speakers",

--- a/scrib-audio/tests/test_diarize_stitch.py
+++ b/scrib-audio/tests/test_diarize_stitch.py
@@ -1,0 +1,152 @@
+"""Unit tests for _stitch_chunks.
+
+These tests exercise the pure-Python stitching logic without loading
+Senko, so they run on any platform and in CI.
+"""
+
+import numpy as np
+
+from scrib_audio.diarize import DiarResult, DiarSegment, _stitch_chunks
+
+
+def _emb(*vals):
+    arr = np.asarray(vals, dtype=np.float32)
+    n = np.linalg.norm(arr)
+    return (arr / n).tolist() if n > 0 else arr.tolist()
+
+
+def test_stitch_empty():
+    r = _stitch_chunks([], [], 0.0)
+    assert r.segments == []
+    assert r.num_speakers == 0
+
+
+def test_stitch_single_chunk_passthrough():
+    chunk = DiarResult(
+        segments=[
+            DiarSegment("SPEAKER_0", 0.0, 2.0),
+            DiarSegment("SPEAKER_1", 2.0, 4.0),
+        ],
+        num_speakers=2,
+        duration_seconds=4.0,
+        speaker_embeddings={"SPEAKER_0": _emb(1, 0), "SPEAKER_1": _emb(0, 1)},
+    )
+    r = _stitch_chunks([chunk], [0.0], 4.0)
+    assert r.num_speakers == 2
+    assert r.segments == chunk.segments
+
+
+def test_stitch_same_speaker_across_chunks_merges():
+    """Two chunks each have SPEAKER_0, with near-identical embeddings.
+
+    They should collapse into a single global SPEAKER_0 and the
+    segments from chunk 1 should be offset into the global timeline.
+    """
+    e = _emb(1, 0, 0)
+    c0 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 5.0)],
+        num_speakers=1,
+        duration_seconds=10.0,
+        speaker_embeddings={"SPEAKER_0": e},
+    )
+    c1 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 2.0, 6.0)],
+        num_speakers=1,
+        duration_seconds=10.0,
+        speaker_embeddings={"SPEAKER_0": e},
+    )
+    # Chunk 1 starts at 8.0s in the global timeline.
+    r = _stitch_chunks([c0, c1], [0.0, 8.0], 14.0)
+
+    assert r.num_speakers == 1
+    # chunk 1's 2.0-6.0 is now 10.0-14.0 globally.
+    speakers = {s.speaker for s in r.segments}
+    assert speakers == {"SPEAKER_0"}
+    ends = [s.end for s in r.segments]
+    assert max(ends) == 14.0
+
+
+def test_stitch_distinct_speakers_allocate_new_labels():
+    """Two chunks with orthogonal speaker embeddings get unique global labels."""
+    c0 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 2.0)],
+        num_speakers=1,
+        duration_seconds=5.0,
+        speaker_embeddings={"SPEAKER_0": _emb(1, 0, 0)},
+    )
+    c1 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 2.0)],
+        num_speakers=1,
+        duration_seconds=5.0,
+        speaker_embeddings={"SPEAKER_0": _emb(0, 1, 0)},
+    )
+    r = _stitch_chunks([c0, c1], [0.0, 5.0], 10.0)
+
+    assert r.num_speakers == 2
+    labels = sorted({s.speaker for s in r.segments})
+    assert labels == ["SPEAKER_0", "SPEAKER_1"]
+
+
+def test_stitch_overlap_dedup():
+    """Same-speaker segments that overlap at the chunk seam collapse."""
+    e = _emb(1, 0)
+    c0 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 10.0)],
+        num_speakers=1,
+        duration_seconds=10.0,
+        speaker_embeddings={"SPEAKER_0": e},
+    )
+    c1 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 5.0)],
+        num_speakers=1,
+        duration_seconds=10.0,
+        speaker_embeddings={"SPEAKER_0": e},
+    )
+    # Chunk 1 starts at 8.0 globally, so its 0-5 → 8-13. Overlaps chunk 0's 0-10.
+    r = _stitch_chunks([c0, c1], [0.0, 8.0], 15.0, merge_gap=0.0)
+
+    assert len(r.segments) == 1
+    assert r.segments[0].speaker == "SPEAKER_0"
+    assert r.segments[0].start == 0.0
+    assert r.segments[0].end == 13.0
+
+
+def test_stitch_three_speakers_across_three_chunks():
+    """A plausible meeting: alice appears in chunks 0+1, bob in chunks 1+2, carol only in chunk 2."""
+    alice = _emb(1, 0, 0)
+    bob = _emb(0, 1, 0)
+    carol = _emb(0, 0, 1)
+
+    c0 = DiarResult(
+        segments=[DiarSegment("SPEAKER_0", 0.0, 4.0)],
+        num_speakers=1,
+        duration_seconds=5.0,
+        speaker_embeddings={"SPEAKER_0": alice},
+    )
+    c1 = DiarResult(
+        segments=[
+            DiarSegment("SPEAKER_0", 0.0, 2.0),
+            DiarSegment("SPEAKER_1", 2.0, 5.0),
+        ],
+        num_speakers=2,
+        duration_seconds=5.0,
+        speaker_embeddings={"SPEAKER_0": alice, "SPEAKER_1": bob},
+    )
+    c2 = DiarResult(
+        segments=[
+            DiarSegment("SPEAKER_0", 0.0, 2.0),
+            DiarSegment("SPEAKER_1", 2.0, 5.0),
+        ],
+        num_speakers=2,
+        duration_seconds=5.0,
+        speaker_embeddings={"SPEAKER_0": bob, "SPEAKER_1": carol},
+    )
+
+    r = _stitch_chunks([c0, c1, c2], [0.0, 4.0, 8.0], 13.0)
+    assert r.num_speakers == 3
+    # All alice segments share a global label, all bob segments share another.
+    segs_by_global: dict[str, list[DiarSegment]] = {}
+    for s in r.segments:
+        segs_by_global.setdefault(s.speaker, []).append(s)
+    # There should be exactly 3 distinct labels.
+    assert len(segs_by_global) == 3


### PR DESCRIPTION
## Summary
- Slides Senko over 10-min windows with 30s overlap inside `diarize_chunked` instead of feeding the full file in one shot.
- Re-clusters per-chunk speaker labels across the whole meeting using CAM++ cosine similarity (threshold 0.70); blends the running centroid per global speaker.
- Dedupes overlap segments across chunk seams before the existing merge pass.
- Emits `diarize_chunk N/M @ Xs` progress events so the TUI SSE stream reflects chunk advancement.

## Why
Metal OOM on long meetings: Senko tries to allocate the full-window attention in one shot and blows past the ~9.5GB Metal buffer ceiling on the M4 Mac Mini. Transcription is left whole-file on purpose — Parakeet already chunks internally at 120s and stitches token-wise; chopping upstream would regress transcript quality.

## Env knobs
- `SCRIB_AUDIO_DIAR_CHUNK_SECS` (default 600)
- `SCRIB_AUDIO_DIAR_OVERLAP_SECS` (default 30)
- `SCRIB_AUDIO_DIAR_MERGE_SIM` (default 0.70, looser than the 0.75 cross-meeting matcher in scrib-server)

## Tests
6 new stitch tests in `tests/test_diarize_stitch.py` covering: empty, single-chunk pass-through, same-speaker merge across chunks, distinct speakers, seam overlap dedup, three-way attribution. Registered `test_align_golden` and `test_diarize_stitch` as py_test targets in BUILD.bazel alongside the existing `test_align`.

`uv run pytest tests/ -v` → 13 passed.