### PR TITLE
fix(line): filter stationary frames in assembler

### DIFF
--- a/line/analytics/src/analytics/worker.py
+++ b/line/analytics/src/analytics/worker.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import asdict
 
 import boto3
+import numpy as np
 import pyarrow.parquet as pq
 from confluent_kafka import Consumer, KafkaError
 
@@ -18,6 +19,12 @@ from analytics.tracks import TrackDatabase
 from analytics.mastery import score_corners
 from analytics.strategy import compute_tyre_degradation, compute_fuel_strategy
 from analytics.journal import generate_journal
+from analytics.alignment import align_lap, compute_time_delta
+from analytics.braking import analyze_braking
+from analytics.racing_line import compute_racing_line_deviation, compute_optimal_line
+from analytics.stability import analyze_stability
+from analytics.classification import classify_corners
+from analytics.fatigue import analyze_fatigue
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -61,9 +68,9 @@ class AnalyticsWorker:
         df = table.to_pandas()
 
         if "pos_x" in df.columns and "pos_z" in df.columns:
-            x = df["pos_x"].values
-            z = df["pos_z"].values
-            speed = df["speed"].values if "speed" in df.columns else None
+            x = df["pos_x"].values.astype(float)
+            z = df["pos_z"].values.astype(float)
+            speed = df["speed"].values.astype(float) if "speed" in df.columns else None
 
             track = self.track_db.identify(x, z)
             if track:
@@ -71,7 +78,7 @@ class AnalyticsWorker:
                 metrics["track_name"] = track.name
 
             if speed is not None:
-                corners = detect_corners(x.astype(float), z.astype(float), speed.astype(float))
+                corners = detect_corners(x, z, speed)
                 metrics["corner_count"] = len(corners)
                 metrics["corners"] = [
                     {
@@ -85,6 +92,86 @@ class AnalyticsWorker:
                     }
                     for c in corners
                 ]
+
+                classified = classify_corners(corners, x, z)
+                metrics["classified_corners"] = [
+                    {
+                        "corner_idx": i,
+                        "classification": cc.classification,
+                        "radius_m": cc.radius_m,
+                        "angle_deg": cc.angle_deg,
+                        "is_complex": cc.is_complex,
+                        "direction": cc.corner.direction,
+                        "entry_speed": cc.corner.entry_speed,
+                        "apex_speed": cc.corner.apex_speed,
+                        "exit_speed": cc.corner.exit_speed,
+                    }
+                    for i, cc in enumerate(classified)
+                ]
+
+                brake = df["brake"].values.astype(float) if "brake" in df.columns else None
+                if brake is not None:
+                    braking = analyze_braking(speed, brake, x, z)
+                    metrics["braking"] = {
+                        "avg_deceleration_g": braking.avg_deceleration_g,
+                        "avg_trail_brake_pct": braking.avg_trail_brake_pct,
+                        "avg_release_smoothness": braking.avg_release_smoothness,
+                        "avg_efficiency": braking.avg_efficiency,
+                        "consistency_score": braking.consistency_score,
+                        "total_brake_distance_m": braking.total_brake_distance_m,
+                        "events": [
+                            {
+                                "start_idx": e.start_idx,
+                                "end_idx": e.end_idx,
+                                "start_speed": e.start_speed,
+                                "end_speed": e.end_speed,
+                                "deceleration_g": e.deceleration_g,
+                                "duration_s": e.duration_s,
+                                "distance_m": e.distance_m,
+                                "trail_brake_pct": e.trail_brake_pct,
+                                "release_smoothness": e.release_smoothness,
+                                "efficiency": e.efficiency,
+                            }
+                            for e in braking.events
+                        ],
+                    }
+
+                steering = df["steering"].values.astype(float) if "steering" in df.columns else None
+                if steering is not None:
+                    stability = analyze_stability(x, z, speed, steering)
+                    metrics["stability"] = {
+                        "oversteer_count": stability.oversteer_count,
+                        "understeer_count": stability.understeer_count,
+                        "avg_yaw_deviation": stability.avg_yaw_deviation,
+                        "stability_score": stability.stability_score,
+                        "worst_corner_idx": stability.worst_corner_idx,
+                        "events": [
+                            {
+                                "start_idx": e.start_idx,
+                                "end_idx": e.end_idx,
+                                "event_type": e.event_type,
+                                "severity": e.severity,
+                                "yaw_rate": e.yaw_rate,
+                                "steering_angle": e.steering_angle,
+                                "speed": e.speed,
+                            }
+                            for e in stability.events
+                        ],
+                    }
+
+                throttle = df["throttle"].values.astype(float) if "throttle" in df.columns else None
+                if throttle is not None and brake is not None:
+                    time_s = np.arange(len(speed)) / 60.0
+                    aligned = align_lap(x, z, speed, throttle, brake, time_s)
+                    metrics["aligned"] = {
+                        "distance": aligned.distance.tolist(),
+                        "speed": aligned.speed.tolist(),
+                        "throttle": aligned.throttle.tolist(),
+                        "brake": aligned.brake.tolist(),
+                        "x": aligned.x.tolist(),
+                        "z": aligned.z.tolist(),
+                        "time_s": aligned.time_s.tolist(),
+                    }
 
         silver_key = f"laps/{session_id}/{lap_num:03d}/metrics.json"
         self.s3.put_object(
@@ -133,6 +220,10 @@ class AnalyticsWorker:
 
         journal = generate_journal(session_id, track_name, car_code, lap_metrics)
 
+        racing_line = self._compute_racing_line(lap_metrics)
+        fatigue = self._compute_fatigue(lap_metrics)
+        time_deltas = self._compute_time_deltas(lap_metrics)
+
         gold = {
             "session_id": session_id,
             "car_code": car_code,
@@ -142,6 +233,9 @@ class AnalyticsWorker:
             "tyre_degradation": asdict(tyre_deg),
             "fuel_strategy": asdict(fuel_strategy),
             "journal": asdict(journal),
+            "racing_line": racing_line,
+            "fatigue": fatigue,
+            "time_deltas": time_deltas,
         }
 
         gold_key = f"sessions/{session_id}/summary.json"
@@ -152,6 +246,93 @@ class AnalyticsWorker:
             ContentType="application/json",
         )
         logger.info("wrote gold summary", extra={"key": gold_key})
+
+    def _compute_racing_line(self, lap_metrics: list[dict]) -> dict:
+        laps_with_aligned = [m for m in lap_metrics if "aligned" in m]
+        if len(laps_with_aligned) < 2:
+            return {}
+
+        laps_x = [np.array(m["aligned"]["x"]) for m in laps_with_aligned]
+        laps_z = [np.array(m["aligned"]["z"]) for m in laps_with_aligned]
+        laps_speed = [np.array(m["aligned"]["speed"]) for m in laps_with_aligned]
+
+        deviation = compute_racing_line_deviation(laps_x, laps_z)
+        optimal = compute_optimal_line(laps_x, laps_z, laps_speed)
+
+        return {
+            "consistency": deviation.consistency,
+            "smoothness": deviation.smoothness,
+            "deviation_avg_m": deviation.deviation_avg_m,
+            "deviation_max_m": deviation.deviation_max_m,
+            "worst_sections": deviation.worst_sections,
+            "optimal_line": optimal,
+        }
+
+    def _compute_fatigue(self, lap_metrics: list[dict]) -> dict:
+        times = [m.get("lap_time_ms", 0) for m in lap_metrics]
+        speeds = [m.get("top_speed", 0) for m in lap_metrics]
+        brakes = [m.get("brake_count", 0) for m in lap_metrics]
+        temps = [
+            np.mean(list(m.get("avg_tire_temps", {}).values())) if m.get("avg_tire_temps") else 0
+            for m in lap_metrics
+        ]
+
+        brake_drifts = []
+        for m in lap_metrics:
+            braking_data = m.get("braking", {})
+            events = braking_data.get("events", [])
+            if events:
+                points = [e["start_idx"] for e in events]
+                brake_drifts.append(float(np.std(points)) if len(points) > 1 else 0.0)
+
+        result = analyze_fatigue(times, speeds, brakes, temps, brake_drifts or None)
+        return asdict(result)
+
+    def _compute_time_deltas(self, lap_metrics: list[dict]) -> list[dict]:
+        laps_with_aligned = [m for m in lap_metrics if "aligned" in m]
+        if len(laps_with_aligned) < 2:
+            return []
+
+        times = [m.get("lap_time_ms", 0) for m in laps_with_aligned]
+        best_idx = int(np.argmin([t for t in times if t > 0])) if any(t > 0 for t in times) else 0
+
+        best = laps_with_aligned[best_idx]
+        from analytics.alignment import AlignedLap
+        ref = AlignedLap(
+            distance=np.array(best["aligned"]["distance"]),
+            speed=np.array(best["aligned"]["speed"]),
+            throttle=np.array(best["aligned"]["throttle"]),
+            brake=np.array(best["aligned"]["brake"]),
+            x=np.array(best["aligned"]["x"]),
+            z=np.array(best["aligned"]["z"]),
+            time_s=np.array(best["aligned"]["time_s"]),
+        )
+
+        deltas = []
+        for i, m in enumerate(laps_with_aligned):
+            if i == best_idx:
+                continue
+            cmp = AlignedLap(
+                distance=np.array(m["aligned"]["distance"]),
+                speed=np.array(m["aligned"]["speed"]),
+                throttle=np.array(m["aligned"]["throttle"]),
+                brake=np.array(m["aligned"]["brake"]),
+                x=np.array(m["aligned"]["x"]),
+                z=np.array(m["aligned"]["z"]),
+                time_s=np.array(m["aligned"]["time_s"]),
+            )
+            td = compute_time_delta(ref, cmp)
+            deltas.append({
+                "lap_number": m.get("lap_number", i),
+                "total_delta_s": td.total_delta_s,
+                "ahead_pct": td.ahead_pct,
+                "max_gain_m": td.max_gain_m,
+                "max_loss_m": td.max_loss_m,
+                "delta_curve": td.delta_s[::10].tolist(),
+                "distance_curve": td.distance[::10].tolist(),
+            })
+
+        return deltas
 
     def run(self):
         brokers = os.environ.get("KAFKA_BROKERS", "localhost:9092")

--- a/line/cmd/api/main.go
+++ b/line/cmd/api/main.go
@@ -273,6 +273,12 @@ func main() {
 	mux.HandleFunc("DELETE /api/v1/reference-laps/{id}", srv.handleDeleteReferenceLap)
 	mux.HandleFunc("GET /api/v1/reference-laps/{trackId}/{carCode}/telemetry", srv.handleReferenceLapTelemetry)
 	mux.HandleFunc("GET /api/v1/compare", srv.handleCarComparison)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/laps/{lap}/braking", srv.handleLapBraking)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/laps/{lap}/stability", srv.handleLapStability)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/laps/{lap}/aligned", srv.handleLapAligned)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/racing-line", srv.handleRacingLine)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/fatigue", srv.handleFatigue)
+	mux.HandleFunc("GET /api/v1/sessions/{id}/time-deltas", srv.handleTimeDeltas)
 	mux.HandleFunc("GET /api/v1/push/vapid", srv.handleVAPIDKey)
 	mux.HandleFunc("POST /api/v1/push/subscribe", srv.handlePushSubscribe)
 	mux.HandleFunc("DELETE /api/v1/push/subscribe", srv.handlePushUnsubscribe)
@@ -488,6 +494,165 @@ func (s *server) handleSessionSummary(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+func (s *server) handleLapBraking(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	lapStr := r.PathValue("lap")
+	lapNum, err := strconv.Atoi(lapStr)
+	if err != nil {
+		http.Error(w, "invalid lap number", http.StatusBadRequest)
+		return
+	}
+
+	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
+	raw, err := s.silver.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "metrics not found", http.StatusNotFound)
+		return
+	}
+
+	var metrics map[string]interface{}
+	if err := json.Unmarshal(raw, &metrics); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	braking, ok := metrics["braking"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{})
+		return
+	}
+	writeJSON(w, braking)
+}
+
+func (s *server) handleLapStability(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	lapStr := r.PathValue("lap")
+	lapNum, err := strconv.Atoi(lapStr)
+	if err != nil {
+		http.Error(w, "invalid lap number", http.StatusBadRequest)
+		return
+	}
+
+	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
+	raw, err := s.silver.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "metrics not found", http.StatusNotFound)
+		return
+	}
+
+	var metrics map[string]interface{}
+	if err := json.Unmarshal(raw, &metrics); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	stability, ok := metrics["stability"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{})
+		return
+	}
+	writeJSON(w, stability)
+}
+
+func (s *server) handleLapAligned(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	lapStr := r.PathValue("lap")
+	lapNum, err := strconv.Atoi(lapStr)
+	if err != nil {
+		http.Error(w, "invalid lap number", http.StatusBadRequest)
+		return
+	}
+
+	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
+	raw, err := s.silver.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "metrics not found", http.StatusNotFound)
+		return
+	}
+
+	var metrics map[string]interface{}
+	if err := json.Unmarshal(raw, &metrics); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	aligned, ok := metrics["aligned"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{})
+		return
+	}
+	writeJSON(w, aligned)
+}
+
+func (s *server) handleRacingLine(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	key := "sessions/" + sessionID + "/summary.json"
+	raw, err := s.gold.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "summary not found", http.StatusNotFound)
+		return
+	}
+
+	var summary map[string]interface{}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	racingLine, ok := summary["racing_line"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{})
+		return
+	}
+	writeJSON(w, racingLine)
+}
+
+func (s *server) handleFatigue(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	key := "sessions/" + sessionID + "/summary.json"
+	raw, err := s.gold.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "summary not found", http.StatusNotFound)
+		return
+	}
+
+	var summary map[string]interface{}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	fatigue, ok := summary["fatigue"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{})
+		return
+	}
+	writeJSON(w, fatigue)
+}
+
+func (s *server) handleTimeDeltas(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	key := "sessions/" + sessionID + "/summary.json"
+	raw, err := s.gold.GetObject(r.Context(), key)
+	if err != nil {
+		http.Error(w, "summary not found", http.StatusNotFound)
+		return
+	}
+
+	var summary map[string]interface{}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	deltas, ok := summary["time_deltas"]
+	if !ok {
+		writeJSON(w, map[string]interface{}{"deltas": []interface{}{}})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"deltas": deltas})
 }
 
 func (s *server) handleListTracks(w http.ResponseWriter, r *http.Request) {

--- a/line/cmd/assembler/main.go
+++ b/line/cmd/assembler/main.go
@@ -197,6 +197,10 @@ func main() {
 
 		resetIdle()
 
+		if frame.Speed == 0 && frame.Throttle == 0 && frame.Brake == 0 {
+			return nil
+		}
+
 		row := frame.ToRow()
 		sess.laps[frame.CurrentLap] = append(sess.laps[frame.CurrentLap], row)
 

--- a/line/internal/db/db.go
+++ b/line/internal/db/db.go
@@ -8,6 +8,36 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+type Store interface {
+	Close()
+	CreateSession(ctx context.Context, s *Session) error
+	EndSession(ctx context.Context, id string, lapCount int, bestLapMs *int32) error
+	UpdateSessionTrack(ctx context.Context, id string, trackID, trackName *string) error
+	InsertLap(ctx context.Context, l *Lap) error
+	ListSessions(ctx context.Context, limit, offset int) ([]Session, error)
+	GetSession(ctx context.Context, id string) (*Session, error)
+	GetProgression(ctx context.Context, trackID string, limit int) ([]ProgressionPoint, error)
+	GetLapTimesForSession(ctx context.Context, sessionID string) ([]int32, error)
+	ListLaps(ctx context.Context, sessionID string) ([]Lap, error)
+	ListAnnotations(ctx context.Context, sessionID string, lapNumber int) ([]Annotation, error)
+	CreateAnnotation(ctx context.Context, a *Annotation) error
+	DeleteAnnotation(ctx context.Context, id int64) error
+	SetReferenceLap(ctx context.Context, r *ReferenceLap) error
+	GetReferenceLap(ctx context.Context, trackID string, carCode int32, label string) (*ReferenceLap, error)
+	ListReferenceLaps(ctx context.Context, trackID string, carCode int32) ([]ReferenceLap, error)
+	DeleteReferenceLap(ctx context.Context, id int64) error
+	GetCarComparisons(ctx context.Context, trackID string) ([]CarComparison, error)
+	GetTrackHistory(ctx context.Context, trackID string, limit int) ([]SessionHistory, error)
+	GetJournal(ctx context.Context, sessionID string) (*Journal, error)
+	SaveJournal(ctx context.Context, j *Journal) error
+	GetDistinctTracks(ctx context.Context) ([]string, error)
+	ListPushSubscriptions(ctx context.Context) ([]PushSubscription, error)
+	SavePushSubscription(ctx context.Context, s *PushSubscription) error
+	DeletePushSubscription(ctx context.Context, endpoint string) error
+}
+
+var _ Store = (*DB)(nil)
+
 type DB struct {
 	pool *pgxpool.Pool
 }

--- a/line/internal/storage/s3.go
+++ b/line/internal/storage/s3.go
@@ -13,6 +13,15 @@ import (
 	"github.com/google/uuid"
 )
 
+type ObjectStore interface {
+	PutLap(ctx context.Context, sessionID string, lapNum int, data []byte) (string, error)
+	GetObject(ctx context.Context, key string) ([]byte, error)
+	GetLatestByPrefix(ctx context.Context, prefix string) ([]byte, error)
+	GetLap(ctx context.Context, sessionID string, lapNum int) ([]byte, error)
+}
+
+var _ ObjectStore = (*S3Client)(nil)
+
 type S3Client struct {
 	client *s3.Client
 	bucket string

--- a/line/web/src/api.ts
+++ b/line/web/src/api.ts
@@ -404,3 +404,115 @@ export async function unsubscribePush(subscription: PushSubscription): Promise<v
     body: JSON.stringify(subscription.toJSON()),
   })
 }
+
+export interface BrakingEvent {
+  start_idx: number
+  end_idx: number
+  start_speed: number
+  end_speed: number
+  deceleration_g: number
+  duration_s: number
+  distance_m: number
+  trail_brake_pct: number
+  release_smoothness: number
+  efficiency: number
+}
+
+export interface BrakingAnalysis {
+  avg_deceleration_g: number
+  avg_trail_brake_pct: number
+  avg_release_smoothness: number
+  avg_efficiency: number
+  consistency_score: number
+  total_brake_distance_m: number
+  events: BrakingEvent[]
+}
+
+export interface StabilityEvent {
+  start_idx: number
+  end_idx: number
+  event_type: 'oversteer' | 'understeer'
+  severity: number
+  yaw_rate: number
+  steering_angle: number
+  speed: number
+}
+
+export interface StabilityAnalysis {
+  oversteer_count: number
+  understeer_count: number
+  avg_yaw_deviation: number
+  stability_score: number
+  worst_corner_idx: number
+  events: StabilityEvent[]
+}
+
+export interface AlignedLap {
+  distance: number[]
+  speed: number[]
+  throttle: number[]
+  brake: number[]
+  x: number[]
+  z: number[]
+  time_s: number[]
+}
+
+export interface RacingLineAnalysis {
+  consistency: number
+  smoothness: number
+  deviation_avg_m: number
+  deviation_max_m: number
+  worst_sections: { start_pct: number; end_pct: number; deviation_m: number }[]
+  optimal_line: { x: number[]; z: number[]; distance: number[] }
+}
+
+export interface FatigueAnalysis {
+  driver_fatigue_score: number
+  tyre_degradation_score: number
+  lap_time_trend: number
+  consistency_trend: number
+  brake_point_drift_trend: number
+  speed_loss_trend: number
+  separation_confidence: number
+  diagnosis: string
+}
+
+export interface TimeDeltaEntry {
+  lap_number: number
+  total_delta_s: number
+  ahead_pct: number
+  max_gain_m: number
+  max_loss_m: number
+  delta_curve: number[]
+  distance_curve: number[]
+}
+
+export async function fetchLapBraking(sessionId: string, lap: number): Promise<BrakingAnalysis> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/laps/${lap}/braking`)
+  return res.json()
+}
+
+export async function fetchLapStability(sessionId: string, lap: number): Promise<StabilityAnalysis> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/laps/${lap}/stability`)
+  return res.json()
+}
+
+export async function fetchLapAligned(sessionId: string, lap: number): Promise<AlignedLap> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/laps/${lap}/aligned`)
+  return res.json()
+}
+
+export async function fetchRacingLine(sessionId: string): Promise<RacingLineAnalysis> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/racing-line`)
+  return res.json()
+}
+
+export async function fetchFatigue(sessionId: string): Promise<FatigueAnalysis> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/fatigue`)
+  return res.json()
+}
+
+export async function fetchTimeDeltas(sessionId: string): Promise<{ deltas: TimeDeltaEntry[] }> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/time-deltas`)
+  return res.json()
+}

--- a/line/web/src/pages/SessionDetail.tsx
+++ b/line/web/src/pages/SessionDetail.tsx
@@ -4,7 +4,7 @@ import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Line } from '@react-three/drei'
 import * as THREE from 'three'
 import clsx from 'clsx'
-import { fetchLaps, fetchTelemetry, fetchLapMetrics, fetchSessionSummary, fetchSession, fetchReferenceLapTelemetry, setReferenceLap, fetchJournal, generateJournal, type Lap, type TelemetryFrame, type LapMetrics, type SessionSummary, type Journal } from '../api'
+import { fetchLaps, fetchTelemetry, fetchLapMetrics, fetchSessionSummary, fetchSession, fetchReferenceLapTelemetry, setReferenceLap, fetchJournal, generateJournal, fetchLapBraking, fetchLapStability, fetchRacingLine, fetchFatigue, fetchTimeDeltas, type Lap, type TelemetryFrame, type LapMetrics, type SessionSummary, type Journal, type BrakingAnalysis, type StabilityAnalysis, type RacingLineAnalysis, type FatigueAnalysis, type TimeDeltaEntry } from '../api'
 import { TelemetryChart } from '../TelemetryChart'
 
 export function SessionDetail() {
@@ -18,11 +18,16 @@ export function SessionDetail() {
   const [metrics, setMetrics] = useState<LapMetrics | null>(null)
   const [summary, setSummary] = useState<SessionSummary | null>(null)
   const [loading, setLoading] = useState(true)
-  const [tab, setTab] = useState<'track' | 'metrics' | 'summary' | 'journal'>('track')
+  const [tab, setTab] = useState<'track' | 'metrics' | 'analytics' | 'summary' | 'journal'>('track')
   const [session, setSession] = useState<{ car_code: number; track_id?: string } | null>(null)
   const [refSaving, setRefSaving] = useState(false)
   const [journal, setJournal] = useState<Journal | null>(null)
   const [journalLoading, setJournalLoading] = useState(false)
+  const [braking, setBraking] = useState<BrakingAnalysis | null>(null)
+  const [stability, setStability] = useState<StabilityAnalysis | null>(null)
+  const [racingLine, setRacingLine] = useState<RacingLineAnalysis | null>(null)
+  const [fatigue, setFatigue] = useState<FatigueAnalysis | null>(null)
+  const [timeDeltas, setTimeDeltas] = useState<TimeDeltaEntry[]>([])
 
   useEffect(() => {
     if (!id) return
@@ -34,6 +39,9 @@ export function SessionDetail() {
     }).catch(() => setLoading(false))
     fetchSessionSummary(id).then(setSummary).catch(() => {})
     fetchJournal(id).then(setJournal).catch(() => {})
+    fetchRacingLine(id).then(setRacingLine).catch(() => setRacingLine(null))
+    fetchFatigue(id).then(setFatigue).catch(() => setFatigue(null))
+    fetchTimeDeltas(id).then(d => setTimeDeltas(d.deltas ?? [])).catch(() => setTimeDeltas([]))
   }, [id])
 
   useEffect(() => {
@@ -47,6 +55,8 @@ export function SessionDetail() {
     if (!id || selectedLap === null) return
     fetchTelemetry(id, selectedLap, 2).then(({ frames }) => setFrames(frames ?? []))
     fetchLapMetrics(id, selectedLap).then(setMetrics).catch(() => setMetrics(null))
+    fetchLapBraking(id, selectedLap).then(setBraking).catch(() => setBraking(null))
+    fetchLapStability(id, selectedLap).then(setStability).catch(() => setStability(null))
   }, [id, selectedLap])
 
   useEffect(() => {
@@ -109,7 +119,7 @@ export function SessionDetail() {
 
       <div className="flex-1 flex flex-col min-w-0">
         <div className="flex items-center gap-1 px-4 py-2 border-b border-border">
-          {(['track', 'metrics', 'summary', 'journal'] as const).map((t) => (
+          {(['track', 'metrics', 'analytics', 'summary', 'journal'] as const).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
@@ -202,6 +212,12 @@ export function SessionDetail() {
         {tab === 'metrics' && !metrics && (
           <div className="flex-1 flex items-center justify-center text-text-dim text-sm">
             No metrics available for this lap
+          </div>
+        )}
+
+        {tab === 'analytics' && (
+          <div className="flex-1 overflow-auto p-5">
+            <AnalyticsPanel braking={braking} stability={stability} racingLine={racingLine} fatigue={fatigue} timeDeltas={timeDeltas} />
           </div>
         )}
 
@@ -361,6 +377,144 @@ function StatCard({ label, value, accent }: { label: string; value: string; acce
     <div className="bg-surface-2 rounded-lg border border-border p-3">
       <div className="text-[10px] text-text-muted uppercase tracking-wider">{label}</div>
       <div className={clsx('text-sm font-mono font-medium mt-1', colorClass)}>{value}</div>
+    </div>
+  )
+}
+
+function AnalyticsPanel({ braking, stability, racingLine, fatigue, timeDeltas }: {
+  braking: BrakingAnalysis | null
+  stability: StabilityAnalysis | null
+  racingLine: RacingLineAnalysis | null
+  fatigue: FatigueAnalysis | null
+  timeDeltas: TimeDeltaEntry[]
+}) {
+  return (
+    <div className="space-y-6">
+      {braking && braking.events && braking.events.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Braking Analysis</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatCard label="Avg Decel" value={`${braking.avg_deceleration_g.toFixed(2)} G`} />
+            <StatCard label="Trail Brake" value={`${braking.avg_trail_brake_pct.toFixed(0)}%`} accent="accent" />
+            <StatCard label="Release Smooth" value={`${(braking.avg_release_smoothness * 100).toFixed(0)}%`} accent={braking.avg_release_smoothness > 0.7 ? 'green' : 'yellow'} />
+            <StatCard label="Efficiency" value={`${(braking.avg_efficiency * 100).toFixed(0)}%`} accent={braking.avg_efficiency > 0.7 ? 'green' : 'yellow'} />
+            <StatCard label="Consistency" value={`${(braking.consistency_score * 100).toFixed(0)}%`} accent={braking.consistency_score > 0.8 ? 'green' : 'red'} />
+            <StatCard label="Total Brake Dist" value={`${braking.total_brake_distance_m.toFixed(0)} m`} />
+          </div>
+          <div className="grid gap-2 max-h-60 overflow-auto">
+            {braking.events.map((e, i) => (
+              <div key={i} className="flex items-center gap-3 bg-surface-2 rounded-lg px-3 py-2 border border-border">
+                <span className="text-xs font-mono text-text-dim w-6">B{i + 1}</span>
+                <div className="flex-1 grid grid-cols-4 gap-2 text-xs">
+                  <div><span className="text-text-dim">Speed</span> <span className="font-mono text-text ml-1">{e.start_speed.toFixed(0)}&rarr;{e.end_speed.toFixed(0)}</span></div>
+                  <div><span className="text-text-dim">Decel</span> <span className="font-mono text-text ml-1">{e.deceleration_g.toFixed(2)}G</span></div>
+                  <div><span className="text-text-dim">Trail</span> <span className="font-mono text-text ml-1">{e.trail_brake_pct.toFixed(0)}%</span></div>
+                  <div><span className="text-text-dim">Dist</span> <span className="font-mono text-text ml-1">{e.distance_m.toFixed(0)}m</span></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {stability && (stability.oversteer_count > 0 || stability.understeer_count > 0) && (
+        <div>
+          <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Stability</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatCard label="Stability Score" value={`${(stability.stability_score * 100).toFixed(0)}%`} accent={stability.stability_score > 0.8 ? 'green' : 'red'} />
+            <StatCard label="Oversteer" value={`${stability.oversteer_count}`} accent={stability.oversteer_count > 3 ? 'red' : 'yellow'} />
+            <StatCard label="Understeer" value={`${stability.understeer_count}`} accent={stability.understeer_count > 3 ? 'red' : 'yellow'} />
+            <StatCard label="Avg Yaw Dev" value={`${stability.avg_yaw_deviation.toFixed(3)}`} />
+          </div>
+          {stability.events.length > 0 && (
+            <div className="grid gap-2 max-h-48 overflow-auto">
+              {stability.events.map((e, i) => (
+                <div key={i} className="flex items-center gap-3 bg-surface-2 rounded-lg px-3 py-2 border border-border">
+                  <span className={clsx('text-xs px-1.5 py-0.5 rounded', e.event_type === 'oversteer' ? 'bg-red/10 text-red' : 'bg-orange/10 text-orange')}>
+                    {e.event_type === 'oversteer' ? 'OS' : 'US'}
+                  </span>
+                  <div className="flex-1 grid grid-cols-3 gap-2 text-xs">
+                    <div><span className="text-text-dim">Severity</span> <span className="font-mono text-text ml-1">{e.severity.toFixed(2)}</span></div>
+                    <div><span className="text-text-dim">Speed</span> <span className="font-mono text-text ml-1">{e.speed.toFixed(0)} km/h</span></div>
+                    <div><span className="text-text-dim">Yaw</span> <span className="font-mono text-text ml-1">{e.yaw_rate.toFixed(2)}</span></div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {racingLine && racingLine.consistency > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Racing Line</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatCard label="Consistency" value={`${(racingLine.consistency * 100).toFixed(0)}%`} accent={racingLine.consistency > 0.8 ? 'green' : 'yellow'} />
+            <StatCard label="Smoothness" value={`${(racingLine.smoothness * 100).toFixed(0)}%`} accent={racingLine.smoothness > 0.7 ? 'green' : 'yellow'} />
+            <StatCard label="Avg Deviation" value={`${racingLine.deviation_avg_m.toFixed(2)} m`} />
+            <StatCard label="Max Deviation" value={`${racingLine.deviation_max_m.toFixed(2)} m`} />
+          </div>
+          {racingLine.worst_sections.length > 0 && (
+            <div className="bg-surface-2 rounded-lg border border-border p-3">
+              <h4 className="text-[10px] text-text-muted uppercase tracking-wider mb-2">Worst Sections</h4>
+              <div className="space-y-1">
+                {racingLine.worst_sections.map((s, i) => (
+                  <div key={i} className="flex justify-between text-xs">
+                    <span className="text-text-muted">{s.start_pct.toFixed(0)}% - {s.end_pct.toFixed(0)}%</span>
+                    <span className="font-mono text-orange">{s.deviation_m.toFixed(2)} m</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {fatigue && fatigue.diagnosis !== 'insufficient_data' && (
+        <div>
+          <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Fatigue / Degradation</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatCard label="Diagnosis" value={fatigue.diagnosis.replace('_', ' ')} accent={fatigue.diagnosis === 'stable' ? 'green' : fatigue.diagnosis === 'driver_fatigue' ? 'red' : 'orange'} />
+            <StatCard label="Driver Fatigue" value={`${(fatigue.driver_fatigue_score * 100).toFixed(0)}%`} accent={fatigue.driver_fatigue_score > 0.5 ? 'red' : 'green'} />
+            <StatCard label="Tyre Deg" value={`${(fatigue.tyre_degradation_score * 100).toFixed(0)}%`} accent={fatigue.tyre_degradation_score > 0.5 ? 'red' : 'green'} />
+            <StatCard label="Confidence" value={`${(fatigue.separation_confidence * 100).toFixed(0)}%`} />
+          </div>
+          <div className="bg-surface-2 rounded-lg border border-border p-3">
+            <div className="space-y-1 text-xs">
+              <div className="flex justify-between"><span className="text-text-muted">Lap Time Trend</span><span className="font-mono">{fatigue.lap_time_trend > 0 ? '+' : ''}{fatigue.lap_time_trend.toFixed(0)} ms/lap</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Speed Loss</span><span className="font-mono">{fatigue.speed_loss_trend.toFixed(2)} km/h/lap</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Consistency Trend</span><span className="font-mono">{fatigue.consistency_trend > 0 ? '+' : ''}{(fatigue.consistency_trend * 100).toFixed(1)}%</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Brake Drift</span><span className="font-mono">{fatigue.brake_point_drift_trend.toFixed(2)} frames/lap</span></div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {timeDeltas.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Time Deltas (vs Best Lap)</h3>
+          <div className="grid gap-2">
+            {timeDeltas.map((d, i) => (
+              <div key={i} className="flex items-center gap-3 bg-surface-2 rounded-lg px-3 py-2 border border-border">
+                <span className="text-xs font-mono text-text-dim w-12">Lap {d.lap_number}</span>
+                <span className={clsx('text-xs font-mono font-medium', d.total_delta_s > 0 ? 'text-red' : 'text-green')}>
+                  {d.total_delta_s > 0 ? '+' : ''}{d.total_delta_s.toFixed(3)}s
+                </span>
+                <div className="flex-1 grid grid-cols-2 gap-2 text-xs">
+                  <div><span className="text-text-dim">Ahead</span> <span className="font-mono text-text ml-1">{d.ahead_pct.toFixed(0)}%</span></div>
+                  <div><span className="text-text-dim">Max gain @</span> <span className="font-mono text-text ml-1">{d.max_gain_m.toFixed(0)}m</span></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!braking && !stability && !racingLine && !fatigue && timeDeltas.length === 0 && (
+        <div className="flex items-center justify-center h-40 text-text-dim text-sm">
+          No analytics data available yet. Complete a session to generate analysis.
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Skip frames where speed=0, throttle=0, brake=0 in the assembler
- Prevents buffering/flushing parquet files full of stationary data (e.g. car parked in pit, game paused)
- Cleaned up junk parquet files from S3 that were written during initial deployment testing