### PR TITLE
perf(line): response caching, lazy loading, parallel analytics

### DIFF
--- a/line/analytics/src/analytics/stability.py
+++ b/line/analytics/src/analytics/stability.py
@@ -35,9 +35,11 @@ def compute_expected_yaw(
     speed: np.ndarray,
     steering: np.ndarray,
     wheelbase: float = 2.5,
+    max_steer_deg: float = 30.0,
 ) -> np.ndarray:
     speed_ms = speed / 3.6
-    steering_rad = steering * np.pi / 180.0
+    steering_normalized = steering / 128.0
+    steering_rad = steering_normalized * max_steer_deg * np.pi / 180.0
     speed_ms = np.where(speed_ms < 1.0, 1.0, speed_ms)
     expected = speed_ms * np.tan(steering_rad) / wheelbase
     return expected

--- a/line/analytics/src/analytics/worker.py
+++ b/line/analytics/src/analytics/worker.py
@@ -5,6 +5,7 @@ import os
 import signal
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 
 import boto3
@@ -44,6 +45,8 @@ class AnalyticsWorker:
         self.gold_bucket = os.environ.get("S3_GOLD_BUCKET", "line-gold")
         self.track_db = TrackDatabase(os.environ.get("TRACK_DATA_DIR", None))
         self.running = True
+        self.max_workers = int(os.environ.get("MAX_WORKERS", "4"))
+        self.executor = ThreadPoolExecutor(max_workers=self.max_workers)
 
     def process_lap(self, event: dict):
         session_id = event.get("session_id", "")
@@ -354,11 +357,16 @@ class AnalyticsWorker:
         signal.signal(signal.SIGINT, shutdown)
         signal.signal(signal.SIGTERM, shutdown)
 
-        logger.info("analytics worker started", extra={"topics": topics, "group": group})
+        logger.info("analytics worker started", extra={"topics": topics, "group": group, "workers": self.max_workers})
+
+        pending_futures = []
 
         while self.running:
-            msg = consumer.poll(1.0)
+            msg = consumer.poll(0.5)
             if msg is None:
+                if pending_futures:
+                    self._drain_futures(pending_futures, consumer)
+                    pending_futures = []
                 continue
             if msg.error():
                 if msg.error().code() == KafkaError._PARTITION_EOF:
@@ -371,16 +379,37 @@ class AnalyticsWorker:
                 topic = msg.topic()
 
                 if topic == "line.lap.written":
-                    self.process_lap(event)
+                    future = self.executor.submit(self.process_lap, event)
+                    pending_futures.append((future, msg))
                 elif topic == "line.session.complete":
+                    if pending_futures:
+                        self._drain_futures(pending_futures, consumer)
+                        pending_futures = []
                     self.process_session_complete(event)
+                    consumer.commit(msg)
 
-                consumer.commit(msg)
+                if len(pending_futures) >= self.max_workers:
+                    self._drain_futures(pending_futures, consumer)
+                    pending_futures = []
+
             except Exception as e:
                 logger.error("processing error: %s", e, exc_info=True)
 
+        if pending_futures:
+            self._drain_futures(pending_futures, consumer)
+        self.executor.shutdown(wait=True)
         consumer.close()
         logger.info("analytics worker stopped")
+
+    def _drain_futures(self, futures_and_msgs, consumer):
+        for future, msg in futures_and_msgs:
+            try:
+                future.result(timeout=120)
+            except Exception as e:
+                logger.error("lap processing failed: %s", e, exc_info=True)
+        if futures_and_msgs:
+            _, last_msg = futures_and_msgs[-1]
+            consumer.commit(last_msg)
 
 
 if __name__ == "__main__":

--- a/line/analytics/tests/test_analytics.py
+++ b/line/analytics/tests/test_analytics.py
@@ -30,27 +30,64 @@ def _make_test_parquet(num_frames: int = 3600) -> bytes:
     x = np.cos(t) * 100 + rng.normal(0, 0.1, num_frames)
     y = np.zeros(num_frames)
     z = np.sin(t) * 100 + rng.normal(0, 0.1, num_frames)
-    speed = 80 + 40 * np.abs(np.sin(t)) + rng.normal(0, 2, num_frames)
-    throttle = np.where(speed > 100, 200.0, 50.0) + rng.normal(0, 5, num_frames)
-    brake = np.where(speed < 60, 150.0, 0.0) + rng.normal(0, 3, num_frames)
-    brake = np.clip(brake, 0, 255)
-    throttle = np.clip(throttle, 0, 255)
-    rpm = speed * 50 + rng.normal(0, 100, num_frames)
-    fuel = np.linspace(100, 95, num_frames)
+    speed = (80 + 40 * np.abs(np.sin(t)) + rng.normal(0, 2, num_frames)).astype(np.float32)
+    throttle = np.clip(np.where(speed > 100, 200, 50) + rng.integers(-5, 5, num_frames), 0, 255).astype(np.int32)
+    brake = np.clip(np.where(speed < 60, 150, 0) + rng.integers(-3, 3, num_frames), 0, 255).astype(np.int32)
+    steering = np.clip((np.sin(t * 2) * 60).astype(np.int32), -128, 127)
+    rpm = (speed * 50 + rng.normal(0, 100, num_frames)).astype(np.float32)
+    fuel = np.linspace(100, 95, num_frames, dtype=np.float32)
 
     table = pa.table({
+        "packet_id": pa.array(np.arange(num_frames, dtype=np.int32)),
         "pos_x": pa.array(x, type=pa.float32()),
         "pos_y": pa.array(y, type=pa.float32()),
         "pos_z": pa.array(z, type=pa.float32()),
-        "speed": pa.array(speed, type=pa.float32()),
-        "throttle": pa.array(throttle, type=pa.float32()),
-        "brake": pa.array(brake, type=pa.float32()),
-        "rpm": pa.array(rpm, type=pa.float32()),
-        "fuel_level": pa.array(fuel, type=pa.float32()),
-        "tire_fl_temp": pa.array(rng.normal(80, 5, num_frames), type=pa.float32()),
-        "tire_fr_temp": pa.array(rng.normal(82, 5, num_frames), type=pa.float32()),
-        "tire_rl_temp": pa.array(rng.normal(78, 5, num_frames), type=pa.float32()),
-        "tire_rr_temp": pa.array(rng.normal(79, 5, num_frames), type=pa.float32()),
+        "vel_x": pa.array(np.gradient(x).astype(np.float32)),
+        "vel_y": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "vel_z": pa.array(np.gradient(z).astype(np.float32)),
+        "rot_pitch": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "rot_yaw": pa.array(np.arctan2(np.gradient(z), np.gradient(x)).astype(np.float32)),
+        "rot_roll": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "ang_vel_x": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "ang_vel_y": pa.array(rng.normal(0, 0.1, num_frames).astype(np.float32)),
+        "ang_vel_z": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "ride_height": pa.array(np.full(num_frames, 0.12, dtype=np.float32)),
+        "rpm": pa.array(rpm),
+        "fuel_level": pa.array(fuel),
+        "fuel_cap": pa.array(np.full(num_frames, 100.0, dtype=np.float32)),
+        "speed": pa.array(speed),
+        "boost": pa.array(np.zeros(num_frames, dtype=np.float32)),
+        "oil_pressure": pa.array(np.full(num_frames, 4.5, dtype=np.float32)),
+        "water_temp": pa.array(np.full(num_frames, 85.0, dtype=np.float32)),
+        "oil_temp": pa.array(np.full(num_frames, 95.0, dtype=np.float32)),
+        "tire_temp_fl": pa.array(rng.normal(80, 5, num_frames).astype(np.float32)),
+        "tire_temp_fr": pa.array(rng.normal(82, 5, num_frames).astype(np.float32)),
+        "tire_temp_rl": pa.array(rng.normal(78, 5, num_frames).astype(np.float32)),
+        "tire_temp_rr": pa.array(rng.normal(79, 5, num_frames).astype(np.float32)),
+        "susp_fl": pa.array(rng.normal(0.1, 0.01, num_frames).astype(np.float32)),
+        "susp_fr": pa.array(rng.normal(0.1, 0.01, num_frames).astype(np.float32)),
+        "susp_rl": pa.array(rng.normal(0.1, 0.01, num_frames).astype(np.float32)),
+        "susp_rr": pa.array(rng.normal(0.1, 0.01, num_frames).astype(np.float32)),
+        "wheel_fl": pa.array(rng.normal(50, 2, num_frames).astype(np.float32)),
+        "wheel_fr": pa.array(rng.normal(50, 2, num_frames).astype(np.float32)),
+        "wheel_rl": pa.array(rng.normal(50, 2, num_frames).astype(np.float32)),
+        "wheel_rr": pa.array(rng.normal(50, 2, num_frames).astype(np.float32)),
+        "tire_rad_fl": pa.array(np.full(num_frames, 0.30, dtype=np.float32)),
+        "tire_rad_fr": pa.array(np.full(num_frames, 0.30, dtype=np.float32)),
+        "tire_rad_rl": pa.array(np.full(num_frames, 0.31, dtype=np.float32)),
+        "tire_rad_rr": pa.array(np.full(num_frames, 0.31, dtype=np.float32)),
+        "current_lap": pa.array(np.ones(num_frames, dtype=np.int32)),
+        "total_laps": pa.array(np.full(num_frames, 5, dtype=np.int32)),
+        "best_lap_ms": pa.array(np.full(num_frames, 90000, dtype=np.int32)),
+        "last_lap_ms": pa.array(np.full(num_frames, 91000, dtype=np.int32)),
+        "current_time_ms": pa.array(np.linspace(0, 60000, num_frames, dtype=np.int32)),
+        "throttle": pa.array(throttle),
+        "brake": pa.array(brake),
+        "steering": pa.array(steering),
+        "gear": pa.array(np.clip((speed / 40).astype(np.int32), 1, 6)),
+        "car_id": pa.array(np.full(num_frames, 3447, dtype=np.int32)),
+        "flags": pa.array(np.ones(num_frames, dtype=np.int32)),
+        "time_of_day": pa.array(np.linspace(43200000, 43260000, num_frames, dtype=np.int32)),
     })
 
     buf = io.BytesIO()
@@ -344,7 +381,7 @@ def test_analyze_stability():
     x = np.cos(t) * 200
     z = np.sin(t) * 200
     speed = 100 + 50 * np.cos(t)
-    steering = np.sin(t) * 30
+    steering = (np.sin(t) * 80).astype(np.int32)
 
     result = analyze_stability(x, z, speed, steering)
     assert result.oversteer_count >= 0
@@ -391,3 +428,157 @@ def test_fatigue_insufficient_data():
 
     result = analyze_fatigue([90000, 91000], [250, 248], [12, 13], [75, 77])
     assert result.diagnosis == "insufficient_data"
+
+
+class FakeS3:
+    def __init__(self):
+        self.objects = {}
+
+    def get_object(self, Bucket, Key):
+        data = self.objects.get(f"{Bucket}/{Key}")
+        if data is None:
+            raise Exception(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": io.BytesIO(data)}
+
+    def put_object(self, Bucket, Key, Body, ContentType=None):
+        self.objects[f"{Bucket}/{Key}"] = Body if isinstance(Body, bytes) else Body.encode()
+
+
+def test_worker_process_lap_e2e():
+    from analytics.worker import AnalyticsWorker
+
+    parquet_data = _make_test_parquet(1800)
+
+    worker = AnalyticsWorker.__new__(AnalyticsWorker)
+    worker.s3 = FakeS3()
+    worker.bronze_bucket = "line-bronze"
+    worker.silver_bucket = "line-silver"
+    worker.gold_bucket = "line-gold"
+    worker.track_db = None
+
+    from analytics.tracks import TrackDatabase
+    worker.track_db = TrackDatabase(None)
+
+    worker.s3.objects["line-bronze/bronze/telemetry/sess-e2e/2026/05/12/lap-001-abc12345.parquet"] = parquet_data
+
+    event = {
+        "session_id": "sess-e2e",
+        "lap_number": 1,
+        "s3_key": "bronze/telemetry/sess-e2e/2026/05/12/lap-001-abc12345.parquet",
+    }
+    worker.process_lap(event)
+
+    silver_key = "line-silver/laps/sess-e2e/001/metrics.json"
+    assert silver_key in worker.s3.objects
+
+    metrics = json.loads(worker.s3.objects[silver_key])
+    assert metrics["session_id"] == "sess-e2e"
+    assert metrics["lap_number"] == 1
+    assert metrics["frame_count"] == 1800
+    assert metrics["total_distance_m"] > 0
+    assert metrics["top_speed"] > 0
+    assert metrics["brake_count"] >= 0
+    assert 0 <= metrics["throttle_pct"] <= 100
+    assert 0 <= metrics["brake_pct"] <= 100
+    assert len(metrics["avg_tire_temps"]) == 4
+    assert metrics["fuel_used"] > 0
+
+    assert "corners" in metrics
+    assert "classified_corners" in metrics
+    assert "braking" in metrics
+    assert metrics["braking"]["avg_deceleration_g"] >= 0
+    assert metrics["braking"]["total_brake_distance_m"] >= 0
+    assert "stability" in metrics
+    assert metrics["stability"]["stability_score"] >= 0
+    assert "aligned" in metrics
+    assert len(metrics["aligned"]["distance"]) == 1000
+    assert len(metrics["aligned"]["speed"]) == 1000
+
+
+def test_worker_process_session_e2e():
+    from analytics.worker import AnalyticsWorker
+    from analytics.tracks import TrackDatabase
+
+    worker = AnalyticsWorker.__new__(AnalyticsWorker)
+    worker.s3 = FakeS3()
+    worker.bronze_bucket = "line-bronze"
+    worker.silver_bucket = "line-silver"
+    worker.gold_bucket = "line-gold"
+    worker.track_db = TrackDatabase(None)
+
+    for lap_num in range(1, 5):
+        parquet_data = _make_test_parquet(1800)
+        bronze_key = f"bronze/telemetry/sess-e2e2/2026/05/12/lap-{lap_num:03d}-abc.parquet"
+        worker.s3.objects[f"line-bronze/{bronze_key}"] = parquet_data
+
+        event = {"session_id": "sess-e2e2", "lap_number": lap_num, "s3_key": bronze_key}
+        worker.process_lap(event)
+
+    for lap_num in range(1, 5):
+        silver_key = f"line-silver/laps/sess-e2e2/{lap_num:03d}/metrics.json"
+        assert silver_key in worker.s3.objects
+
+    session_event = {
+        "session_id": "sess-e2e2",
+        "car_code": 3447,
+        "track_name": "Test Circuit",
+        "lap_count": 4,
+    }
+    worker.process_session_complete(session_event)
+
+    gold_key = "line-gold/sessions/sess-e2e2/summary.json"
+    assert gold_key in worker.s3.objects
+
+    summary = json.loads(worker.s3.objects[gold_key])
+    assert summary["session_id"] == "sess-e2e2"
+    assert summary["car_code"] == 3447
+    assert summary["track_name"] == "Test Circuit"
+    assert summary["lap_count"] == 4
+
+    assert "consistency" in summary
+    assert summary["consistency"]["lap_count"] >= 2
+
+    assert "tyre_degradation" in summary
+    assert len(summary["tyre_degradation"]["avg_temp_per_lap"]) == 4
+
+    assert "fuel_strategy" in summary
+    assert summary["fuel_strategy"]["consumption_per_lap"] > 0
+
+    assert "journal" in summary
+    assert summary["journal"]["total_laps"] == 4
+
+    assert "racing_line" in summary
+    assert summary["racing_line"]["consistency"] > 0
+    assert summary["racing_line"]["deviation_avg_m"] > 0
+
+    assert "fatigue" in summary
+    assert summary["fatigue"]["diagnosis"] in ("stable", "driver_fatigue", "tyre_degradation", "mixed", "insufficient_data")
+
+    assert "time_deltas" in summary
+
+
+def test_worker_steering_int32_handling():
+    parquet_data = _make_test_parquet(600)
+
+    table = pq.read_table(io.BytesIO(parquet_data))
+    df = table.to_pandas()
+
+    assert df["throttle"].dtype in (np.int32, np.int64)
+    assert df["brake"].dtype in (np.int32, np.int64)
+    assert df["steering"].dtype in (np.int32, np.int64)
+
+    assert df["throttle"].min() >= 0
+    assert df["throttle"].max() <= 255
+    assert df["brake"].min() >= 0
+    assert df["brake"].max() <= 255
+    assert df["steering"].min() >= -128
+    assert df["steering"].max() <= 127
+
+    from analytics.stability import analyze_stability
+    x = df["pos_x"].values.astype(float)
+    z = df["pos_z"].values.astype(float)
+    speed = df["speed"].values.astype(float)
+    steering = df["steering"].values.astype(float)
+
+    result = analyze_stability(x, z, speed, steering)
+    assert 0 <= result.stability_score <= 1

--- a/line/cmd/api/analytics.go
+++ b/line/cmd/api/analytics.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+
+	"github.com/solanyn/mono/line/internal/storage"
 )
 
 func (s *server) handleLapMetrics(w http.ResponseWriter, r *http.Request) {
@@ -18,26 +20,28 @@ func (s *server) handleLapMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	key := "laps/" + sessionID + "/" + strconv.Itoa(lapNum) + "/metrics.json"
-	data, err := s.silver.GetObject(r.Context(), key)
+	data, err := s.getCachedS3(r, s.silver, "silver:"+key, key)
 	if err != nil {
 		http.Error(w, "metrics not found", http.StatusNotFound)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
 	w.Write(data)
 }
 
 func (s *server) handleSessionSummary(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	key := "sessions/" + sessionID + "/summary.json"
-	data, err := s.gold.GetObject(r.Context(), key)
+	data, err := s.getCachedS3(r, s.gold, "gold:"+key, key)
 	if err != nil {
 		http.Error(w, "summary not found", http.StatusNotFound)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
 	w.Write(data)
 }
 
@@ -51,7 +55,7 @@ func (s *server) handleLapBraking(w http.ResponseWriter, r *http.Request) {
 	}
 
 	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
-	raw, err := s.silver.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.silver, "silver:"+key, key)
 	if err != nil {
 		http.Error(w, "metrics not found", http.StatusNotFound)
 		return
@@ -68,6 +72,7 @@ func (s *server) handleLapBraking(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
 	writeJSON(w, braking)
 }
 
@@ -81,7 +86,7 @@ func (s *server) handleLapStability(w http.ResponseWriter, r *http.Request) {
 	}
 
 	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
-	raw, err := s.silver.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.silver, "silver:"+key, key)
 	if err != nil {
 		http.Error(w, "metrics not found", http.StatusNotFound)
 		return
@@ -98,6 +103,7 @@ func (s *server) handleLapStability(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
 	writeJSON(w, stability)
 }
 
@@ -111,7 +117,7 @@ func (s *server) handleLapAligned(w http.ResponseWriter, r *http.Request) {
 	}
 
 	key := "laps/" + sessionID + "/" + fmt.Sprintf("%03d", lapNum) + "/metrics.json"
-	raw, err := s.silver.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.silver, "silver:"+key, key)
 	if err != nil {
 		http.Error(w, "metrics not found", http.StatusNotFound)
 		return
@@ -128,13 +134,14 @@ func (s *server) handleLapAligned(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
 	writeJSON(w, aligned)
 }
 
 func (s *server) handleRacingLine(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	key := "sessions/" + sessionID + "/summary.json"
-	raw, err := s.gold.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.gold, "gold:"+key, key)
 	if err != nil {
 		http.Error(w, "summary not found", http.StatusNotFound)
 		return
@@ -152,13 +159,14 @@ func (s *server) handleRacingLine(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=3600")
 	writeJSON(w, racingLine)
 }
 
 func (s *server) handleFatigue(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	key := "sessions/" + sessionID + "/summary.json"
-	raw, err := s.gold.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.gold, "gold:"+key, key)
 	if err != nil {
 		http.Error(w, "summary not found", http.StatusNotFound)
 		return
@@ -175,13 +183,14 @@ func (s *server) handleFatigue(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=3600")
 	writeJSON(w, fatigue)
 }
 
 func (s *server) handleTimeDeltas(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	key := "sessions/" + sessionID + "/summary.json"
-	raw, err := s.gold.GetObject(r.Context(), key)
+	raw, err := s.getCachedS3(r, s.gold, "gold:"+key, key)
 	if err != nil {
 		http.Error(w, "summary not found", http.StatusNotFound)
 		return
@@ -198,5 +207,18 @@ func (s *server) handleTimeDeltas(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{"deltas": []interface{}{}})
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=3600")
 	writeJSON(w, map[string]interface{}{"deltas": deltas})
+}
+
+func (s *server) getCachedS3(r *http.Request, client *storage.S3Client, cacheKey, s3Key string) ([]byte, error) {
+	if data, ok := s.cache.Get(cacheKey); ok {
+		return data, nil
+	}
+	data, err := client.GetObject(r.Context(), s3Key)
+	if err != nil {
+		return nil, err
+	}
+	s.cache.Set(cacheKey, data)
+	return data, nil
 }

--- a/line/cmd/api/cache.go
+++ b/line/cmd/api/cache.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	data      []byte
+	expiresAt time.Time
+}
+
+type responseCache struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+	maxSize int
+	ttl     time.Duration
+}
+
+func newResponseCache(maxSize int, ttl time.Duration) *responseCache {
+	c := &responseCache{
+		entries: make(map[string]cacheEntry, maxSize),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+	go c.evictLoop()
+	return c
+}
+
+func (c *responseCache) Get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.data, true
+}
+
+func (c *responseCache) Set(key string, data []byte) {
+	c.mu.Lock()
+	if len(c.entries) >= c.maxSize {
+		oldest := ""
+		oldestTime := time.Now().Add(time.Hour)
+		for k, v := range c.entries {
+			if v.expiresAt.Before(oldestTime) {
+				oldest = k
+				oldestTime = v.expiresAt
+			}
+		}
+		if oldest != "" {
+			delete(c.entries, oldest)
+		}
+	}
+	c.entries[key] = cacheEntry{data: data, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *responseCache) evictLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		now := time.Now()
+		c.mu.Lock()
+		for k, v := range c.entries {
+			if now.After(v.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/line/cmd/api/main.go
+++ b/line/cmd/api/main.go
@@ -36,6 +36,7 @@ type server struct {
 	coach          *coach.Pipeline
 	database       *db.DB
 	llm            *coach.LLMClient
+	cache          *responseCache
 	cars           []carEntry
 	pushSubs       []webpush.Subscription
 	pushMu         sync.RWMutex
@@ -104,6 +105,7 @@ func main() {
 		coach:          coachPipeline,
 		database:       database,
 		llm:            coach.NewLLMClient(llmEndpoint, llmModel),
+		cache:          newResponseCache(256, 5*time.Minute),
 		vapidPublicKey: vapidPublicKey,
 		vapidPrivate:   vapidPrivateKey,
 	}

--- a/line/cmd/api/sessions.go
+++ b/line/cmd/api/sessions.go
@@ -86,28 +86,67 @@ func (s *server) handleGetTelemetry(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data, err := s.s3.GetLap(r.Context(), sessionID, lapNum)
-	if err != nil {
-		slog.Error("get lap from s3", "session", sessionID, "lap", lapNum, "err", err)
-		http.Error(w, "lap not found", http.StatusNotFound)
-		return
+	offset := 0
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
+			offset = v
+		}
+	}
+	limit := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
 	}
 
-	rows, err := storage.ReadParquet(data)
-	if err != nil {
-		slog.Error("read parquet", "err", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
+	cacheKey := "telemetry:" + sessionID + ":" + lapStr
+	var rows []storage.TelemetryRow
+
+	if cachedRaw, ok := s.cache.Get(cacheKey); ok {
+		var err error
+		rows, err = storage.ReadParquet(cachedRaw)
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		data, err := s.s3.GetLap(r.Context(), sessionID, lapNum)
+		if err != nil {
+			slog.Error("get lap from s3", "session", sessionID, "lap", lapNum, "err", err)
+			http.Error(w, "lap not found", http.StatusNotFound)
+			return
+		}
+		s.cache.Set(cacheKey, data)
+
+		rows, err = storage.ReadParquet(data)
+		if err != nil {
+			slog.Error("read parquet", "err", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	total := len(rows)
+
+	if offset > 0 && offset < len(rows) {
+		rows = rows[offset:]
+	} else if offset >= len(rows) {
+		rows = nil
+	}
+	if limit > 0 && limit < len(rows) {
+		rows = rows[:limit]
 	}
 
 	frames := rowsToFrames(rows, downsample)
 
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
 	writeJSON(w, map[string]interface{}{
 		"session_id": sessionID,
 		"lap_number": lapNum,
 		"frames":     frames,
-		"total":      len(rows),
+		"total":      total,
 		"returned":   len(frames),
+		"offset":     offset,
 	})
 }
 

--- a/line/web/src/main.tsx
+++ b/line/web/src/main.tsx
@@ -1,33 +1,38 @@
-import { StrictMode } from 'react'
+import { StrictMode, lazy, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router'
 import './index.css'
 import { App } from './App'
-import { SessionsPage } from './pages/Sessions'
-import { SessionDetail } from './pages/SessionDetail'
-import { ReplayPage } from './pages/Replay'
-import { BriefingPage } from './pages/Briefing'
-import { LivePage } from './pages/Live'
-import { ProgressionPage } from './pages/Progression'
-import { TracksPage } from './pages/Tracks'
-import { ReferenceLapsPage } from './pages/ReferenceLaps'
-import { ComparePage } from './pages/Compare'
+
+const SessionsPage = lazy(() => import('./pages/Sessions').then(m => ({ default: m.SessionsPage })))
+const SessionDetail = lazy(() => import('./pages/SessionDetail').then(m => ({ default: m.SessionDetail })))
+const ReplayPage = lazy(() => import('./pages/Replay').then(m => ({ default: m.ReplayPage })))
+const BriefingPage = lazy(() => import('./pages/Briefing').then(m => ({ default: m.BriefingPage })))
+const LivePage = lazy(() => import('./pages/Live').then(m => ({ default: m.LivePage })))
+const ProgressionPage = lazy(() => import('./pages/Progression').then(m => ({ default: m.ProgressionPage })))
+const TracksPage = lazy(() => import('./pages/Tracks').then(m => ({ default: m.TracksPage })))
+const ReferenceLapsPage = lazy(() => import('./pages/ReferenceLaps').then(m => ({ default: m.ReferenceLapsPage })))
+const ComparePage = lazy(() => import('./pages/Compare').then(m => ({ default: m.ComparePage })))
+
+function Loading() {
+  return <div className="flex items-center justify-center h-full text-text-muted text-sm">Loading...</div>
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route element={<App />}>
-          <Route index element={<SessionsPage />} />
-          <Route path="sessions" element={<SessionsPage />} />
-          <Route path="sessions/:id" element={<SessionDetail />} />
-          <Route path="sessions/:id/replay" element={<ReplayPage />} />
-          <Route path="sessions/:id/briefing" element={<BriefingPage />} />
-          <Route path="live" element={<LivePage />} />
-          <Route path="progression" element={<ProgressionPage />} />
-          <Route path="tracks" element={<TracksPage />} />
-          <Route path="reference" element={<ReferenceLapsPage />} />
-          <Route path="compare" element={<ComparePage />} />
+          <Route index element={<Suspense fallback={<Loading />}><SessionsPage /></Suspense>} />
+          <Route path="sessions" element={<Suspense fallback={<Loading />}><SessionsPage /></Suspense>} />
+          <Route path="sessions/:id" element={<Suspense fallback={<Loading />}><SessionDetail /></Suspense>} />
+          <Route path="sessions/:id/replay" element={<Suspense fallback={<Loading />}><ReplayPage /></Suspense>} />
+          <Route path="sessions/:id/briefing" element={<Suspense fallback={<Loading />}><BriefingPage /></Suspense>} />
+          <Route path="live" element={<Suspense fallback={<Loading />}><LivePage /></Suspense>} />
+          <Route path="progression" element={<Suspense fallback={<Loading />}><ProgressionPage /></Suspense>} />
+          <Route path="tracks" element={<Suspense fallback={<Loading />}><TracksPage /></Suspense>} />
+          <Route path="reference" element={<Suspense fallback={<Loading />}><ReferenceLapsPage /></Suspense>} />
+          <Route path="compare" element={<Suspense fallback={<Loading />}><ComparePage /></Suspense>} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- Frontend lazy route loading (React.lazy/Suspense) — Three.js and Recharts only loaded when needed
- In-memory response cache (256 entries, 5min TTL) for S3 objects with Cache-Control headers
- Telemetry endpoint supports offset/limit pagination for large laps
- Analytics worker uses ThreadPoolExecutor (4 workers) for parallel lap processing
- Fix steering interpretation in stability.py (raw byte, not degrees)
- Add 3 e2e tests for analytics worker pipeline