### PR TITLE
feat(line): frontend polish — error boundaries, theme, a11y, animations

### DIFF
--- a/line/web/src/App.tsx
+++ b/line/web/src/App.tsx
@@ -1,33 +1,42 @@
 import { NavLink, Outlet } from 'react-router'
 import clsx from 'clsx'
+import { ThemeToggle } from './components/ThemeProvider'
+
+const navItems = [
+  { to: '/', label: 'Sessions', end: true },
+  { to: '/progression', label: 'Progression' },
+  { to: '/tracks', label: 'Tracks' },
+  { to: '/reference', label: 'Reference' },
+  { to: '/compare', label: 'Compare' },
+  { to: '/live', label: 'Live' },
+] as const
 
 export function App() {
   return (
     <div className="flex flex-col h-screen bg-bg text-text">
-      <header className="flex items-center gap-4 sm:gap-6 px-4 sm:px-5 py-3 border-b border-border">
+      <a href="#main-content" className="skip-link">Skip to content</a>
+      <header className="flex items-center gap-4 sm:gap-6 px-4 sm:px-5 py-3 border-b border-border" role="banner">
         <h1 className="text-lg font-semibold tracking-tight">line</h1>
-        <nav className="flex gap-3 sm:gap-4 text-sm">
-          <NavLink to="/" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')} end>
-            Sessions
-          </NavLink>
-          <NavLink to="/progression" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')}>
-            Progression
-          </NavLink>
-          <NavLink to="/tracks" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')}>
-            Tracks
-          </NavLink>
-          <NavLink to="/reference" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')}>
-            Reference
-          </NavLink>
-          <NavLink to="/compare" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')}>
-            Compare
-          </NavLink>
-          <NavLink to="/live" className={({ isActive }: { isActive: boolean }) => clsx('transition-colors', isActive ? 'text-accent' : 'text-text-muted hover:text-text')}>
-            Live
-          </NavLink>
+        <nav className="flex gap-3 sm:gap-4 text-sm overflow-x-auto" aria-label="Main navigation">
+          {navItems.map(({ to, label, ...rest }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }: { isActive: boolean }) => clsx(
+                'transition-colors whitespace-nowrap',
+                isActive ? 'text-accent' : 'text-text-muted hover:text-text',
+              )}
+              {...rest}
+            >
+              {label}
+            </NavLink>
+          ))}
         </nav>
+        <div className="ml-auto flex items-center gap-2">
+          <ThemeToggle />
+        </div>
       </header>
-      <main className="flex-1 overflow-hidden">
+      <main id="main-content" className="flex-1 overflow-hidden" role="main">
         <Outlet />
       </main>
     </div>

--- a/line/web/src/TelemetryChart.tsx
+++ b/line/web/src/TelemetryChart.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { useMemo, useState, useCallback, useRef } from 'react'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceArea } from 'recharts'
 import type { TelemetryFrame } from './api'
 
 interface TelemetryChartProps {
@@ -26,6 +26,12 @@ function framesToData(frames: TelemetryFrame[]) {
 }
 
 export function TelemetryChart({ frames, compareFrames }: TelemetryChartProps) {
+  const [zoomLeft, setZoomLeft] = useState<number | null>(null)
+  const [zoomRight, setZoomRight] = useState<number | null>(null)
+  const [selecting, setSelecting] = useState(false)
+  const [domain, setDomain] = useState<[number, number] | null>(null)
+  const chartRef = useRef<HTMLDivElement>(null)
+
   const data = useMemo(() => {
     if (!frames || frames.length === 0) return []
     return framesToData(frames)
@@ -46,22 +52,75 @@ export function TelemetryChart({ frames, compareFrames }: TelemetryChartProps) {
     }))
   }, [data, compareData])
 
+  const visibleData = useMemo(() => {
+    if (!domain) return merged
+    return merged.filter(d => d.distance >= domain[0] && d.distance <= domain[1])
+  }, [merged, domain])
+
+  const handleMouseDown = useCallback((e: unknown) => {
+    const ev = e as { activeLabel?: string } | undefined
+    if (ev?.activeLabel) {
+      setZoomLeft(Number(ev.activeLabel))
+      setSelecting(true)
+    }
+  }, [])
+
+  const handleMouseMove = useCallback((e: unknown) => {
+    const ev = e as { activeLabel?: string } | undefined
+    if (selecting && ev?.activeLabel) {
+      setZoomRight(Number(ev.activeLabel))
+    }
+  }, [selecting])
+
+  const handleMouseUp = useCallback(() => {
+    if (zoomLeft !== null && zoomRight !== null && zoomLeft !== zoomRight) {
+      const left = Math.min(zoomLeft, zoomRight)
+      const right = Math.max(zoomLeft, zoomRight)
+      setDomain([left, right])
+    }
+    setZoomLeft(null)
+    setZoomRight(null)
+    setSelecting(false)
+  }, [zoomLeft, zoomRight])
+
+  const resetZoom = useCallback(() => setDomain(null), [])
+
   if (merged.length === 0) {
     return <div className="text-xs text-text-dim text-center py-8">Select a lap to view telemetry</div>
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" ref={chartRef} role="img" aria-label="Telemetry charts showing speed, throttle and brake over distance">
+      {domain && (
+        <button
+          onClick={resetZoom}
+          className="text-[10px] text-accent hover:text-text transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 rounded px-2 py-0.5"
+          aria-label="Reset chart zoom"
+        >
+          Reset zoom
+        </button>
+      )}
       <div>
         <h3 className="text-xs text-text-muted mb-1">Speed (km/h)</h3>
         <ResponsiveContainer width="100%" height={100}>
-          <LineChart data={merged}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
-            <XAxis dataKey="distance" stroke="#555" tick={{ fontSize: 9 }} />
-            <YAxis stroke="#555" tick={{ fontSize: 9 }} />
-            <Tooltip contentStyle={{ background: '#1a1a1a', border: '1px solid #333', fontSize: 11 }} />
-            <Line type="monotone" dataKey="speed" stroke="#4fc3f7" dot={false} strokeWidth={1.5} />
-            {compareData && <Line type="monotone" dataKey="speed2" stroke="#ff7043" dot={false} strokeWidth={1} strokeDasharray="4 2" />}
+          <LineChart
+            data={visibleData}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+            <XAxis dataKey="distance" stroke="var(--color-text-dim)" tick={{ fontSize: 9 }} />
+            <YAxis stroke="var(--color-text-dim)" tick={{ fontSize: 9 }} />
+            <Tooltip
+              contentStyle={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border-2)', fontSize: 11, borderRadius: 6 }}
+              labelFormatter={(v) => `${v}m`}
+            />
+            <Line type="monotone" dataKey="speed" stroke="var(--color-accent)" dot={false} strokeWidth={1.5} animationDuration={300} />
+            {compareData && <Line type="monotone" dataKey="speed2" stroke="var(--color-orange)" dot={false} strokeWidth={1} strokeDasharray="4 2" animationDuration={300} />}
+            {selecting && zoomLeft !== null && zoomRight !== null && (
+              <ReferenceArea x1={zoomLeft} x2={zoomRight} strokeOpacity={0.3} fill="var(--color-accent)" fillOpacity={0.1} />
+            )}
           </LineChart>
         </ResponsiveContainer>
       </div>
@@ -69,18 +128,23 @@ export function TelemetryChart({ frames, compareFrames }: TelemetryChartProps) {
       <div>
         <h3 className="text-xs text-text-muted mb-1">Throttle / Brake (%)</h3>
         <ResponsiveContainer width="100%" height={80}>
-          <LineChart data={merged}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
-            <XAxis dataKey="distance" stroke="#555" tick={{ fontSize: 9 }} />
-            <YAxis stroke="#555" tick={{ fontSize: 9 }} domain={[0, 100]} />
-            <Tooltip contentStyle={{ background: '#1a1a1a', border: '1px solid #333', fontSize: 11 }} />
-            <Line type="monotone" dataKey="throttle" stroke="#66bb6a" dot={false} strokeWidth={1.5} />
-            <Line type="monotone" dataKey="brake" stroke="#ef5350" dot={false} strokeWidth={1.5} />
-            {compareData && <Line type="monotone" dataKey="throttle2" stroke="#66bb6a" dot={false} strokeWidth={1} strokeDasharray="4 2" opacity={0.5} />}
-            {compareData && <Line type="monotone" dataKey="brake2" stroke="#ef5350" dot={false} strokeWidth={1} strokeDasharray="4 2" opacity={0.5} />}
+          <LineChart data={visibleData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+            <XAxis dataKey="distance" stroke="var(--color-text-dim)" tick={{ fontSize: 9 }} />
+            <YAxis stroke="var(--color-text-dim)" tick={{ fontSize: 9 }} domain={[0, 100]} />
+            <Tooltip
+              contentStyle={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border-2)', fontSize: 11, borderRadius: 6 }}
+              labelFormatter={(v) => `${v}m`}
+            />
+            <Line type="monotone" dataKey="throttle" stroke="var(--color-green)" dot={false} strokeWidth={1.5} animationDuration={300} />
+            <Line type="monotone" dataKey="brake" stroke="var(--color-red)" dot={false} strokeWidth={1.5} animationDuration={300} />
+            {compareData && <Line type="monotone" dataKey="throttle2" stroke="var(--color-green)" dot={false} strokeWidth={1} strokeDasharray="4 2" opacity={0.5} animationDuration={300} />}
+            {compareData && <Line type="monotone" dataKey="brake2" stroke="var(--color-red)" dot={false} strokeWidth={1} strokeDasharray="4 2" opacity={0.5} animationDuration={300} />}
           </LineChart>
         </ResponsiveContainer>
       </div>
+
+      <p className="text-[10px] text-text-dim" aria-hidden="true">Drag to zoom. {compareData ? 'Dashed lines = comparison lap.' : ''}</p>
     </div>
   )
 }

--- a/line/web/src/components/ErrorBoundary.tsx
+++ b/line/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback
+      return (
+        <div className="flex flex-col items-center justify-center h-full gap-4 p-8" role="alert">
+          <div className="w-12 h-12 rounded-full bg-red/10 flex items-center justify-center">
+            <svg className="w-6 h-6 text-red" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+          </div>
+          <div className="text-center">
+            <h2 className="text-sm font-medium text-text mb-1">Something went wrong</h2>
+            <p className="text-xs text-text-muted max-w-sm">{this.state.error.message}</p>
+          </div>
+          <button
+            onClick={() => this.setState({ error: null })}
+            className="px-4 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50"
+          >
+            Try again
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/line/web/src/components/Skeleton.tsx
+++ b/line/web/src/components/Skeleton.tsx
@@ -1,0 +1,59 @@
+import clsx from 'clsx'
+
+interface SkeletonProps {
+  className?: string
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={clsx('animate-pulse rounded bg-border/50', className)}
+      aria-hidden="true"
+    />
+  )
+}
+
+export function SessionCardSkeleton() {
+  return (
+    <div className="flex justify-between items-center p-4 bg-surface-2 rounded-lg border border-border animate-pulse">
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+      <div className="space-y-2 flex flex-col items-end">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  )
+}
+
+export function LapListSkeleton() {
+  return (
+    <div className="space-y-1 p-3" aria-label="Loading laps">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton key={i} className="h-8 w-full" />
+      ))}
+    </div>
+  )
+}
+
+export function ChartSkeleton() {
+  return (
+    <div className="p-4 space-y-3 animate-pulse" aria-label="Loading chart">
+      <Skeleton className="h-3 w-24" />
+      <Skeleton className="h-28 w-full rounded-md" />
+      <Skeleton className="h-3 w-32 mt-4" />
+      <Skeleton className="h-28 w-full rounded-md" />
+    </div>
+  )
+}
+
+export function MetricCardSkeleton() {
+  return (
+    <div className="p-3 bg-surface-2 rounded-lg border border-border animate-pulse">
+      <Skeleton className="h-3 w-16 mb-2" />
+      <Skeleton className="h-6 w-24" />
+    </div>
+  )
+}

--- a/line/web/src/components/ThemeProvider.tsx
+++ b/line/web/src/components/ThemeProvider.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
+
+type Theme = 'dark' | 'light' | 'system'
+
+interface ThemeContextValue {
+  theme: Theme
+  resolved: 'dark' | 'light'
+  setTheme: (t: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'system',
+  resolved: 'dark',
+  setTheme: () => {},
+})
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem('line-theme')
+    return (stored as Theme) || 'system'
+  })
+  const [systemDark, setSystemDark] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const resolved = theme === 'system' ? (systemDark ? 'dark' : 'light') : theme
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', resolved)
+  }, [resolved])
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t)
+    localStorage.setItem('line-theme', t)
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolved, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const options: { value: Theme; label: string; icon: string }[] = [
+    { value: 'dark', label: 'Dark', icon: '◐' },
+    { value: 'light', label: 'Light', icon: '○' },
+    { value: 'system', label: 'System', icon: '◑' },
+  ]
+
+  return (
+    <div className="flex items-center gap-0.5 bg-surface rounded-md p-0.5" role="radiogroup" aria-label="Theme">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          role="radio"
+          aria-checked={theme === opt.value}
+          aria-label={opt.label}
+          onClick={() => setTheme(opt.value)}
+          className={`px-2 py-0.5 rounded text-xs transition-colors ${
+            theme === opt.value
+              ? 'bg-accent/15 text-accent'
+              : 'text-text-muted hover:text-text'
+          }`}
+        >
+          {opt.icon}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/line/web/src/hooks/useAsync.ts
+++ b/line/web/src/hooks/useAsync.ts
@@ -1,0 +1,59 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+interface AsyncState<T> {
+  data: T | null
+  loading: boolean
+  error: Error | null
+}
+
+interface UseAsyncReturn<T> extends AsyncState<T> {
+  execute: () => Promise<void>
+  retry: () => Promise<void>
+}
+
+export function useAsync<T>(
+  fn: () => Promise<T>,
+  deps: unknown[] = [],
+  immediate = true,
+): UseAsyncReturn<T> {
+  const [state, setState] = useState<AsyncState<T>>({
+    data: null,
+    loading: immediate,
+    error: null,
+  })
+  const mountedRef = useRef(true)
+  const retryCountRef = useRef(0)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  const execute = useCallback(async () => {
+    setState(s => ({ ...s, loading: true, error: null }))
+    try {
+      const data = await fn()
+      if (mountedRef.current) {
+        setState({ data, loading: false, error: null })
+        retryCountRef.current = 0
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setState(s => ({ ...s, loading: false, error: err as Error }))
+      }
+    }
+  }, deps)
+
+  const retry = useCallback(async () => {
+    retryCountRef.current++
+    const delay = Math.min(1000 * 2 ** retryCountRef.current, 10000)
+    await new Promise(r => setTimeout(r, delay))
+    return execute()
+  }, [execute])
+
+  useEffect(() => {
+    if (immediate) execute()
+  }, [execute, immediate])
+
+  return { ...state, execute, retry }
+}

--- a/line/web/src/hooks/useKeyboard.ts
+++ b/line/web/src/hooks/useKeyboard.ts
@@ -1,0 +1,34 @@
+import { useEffect, useCallback } from 'react'
+
+type KeyHandler = (e: KeyboardEvent) => void
+
+interface KeyMap {
+  [key: string]: KeyHandler
+}
+
+export function useKeyboard(keyMap: KeyMap, deps: unknown[] = []) {
+  const handler = useCallback((e: KeyboardEvent) => {
+    const key = [
+      e.ctrlKey && 'ctrl',
+      e.metaKey && 'meta',
+      e.shiftKey && 'shift',
+      e.altKey && 'alt',
+      e.key.toLowerCase(),
+    ].filter(Boolean).join('+')
+
+    const fn = keyMap[key] || keyMap[e.key.toLowerCase()]
+    if (fn) {
+      e.preventDefault()
+      fn(e)
+    }
+  }, deps)
+
+  useEffect(() => {
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [handler])
+}
+
+export function useEscape(handler: () => void, deps: unknown[] = []) {
+  useKeyboard({ escape: handler }, deps)
+}

--- a/line/web/src/hooks/useSwipe.tsx
+++ b/line/web/src/hooks/useSwipe.tsx
@@ -1,0 +1,120 @@
+import { useRef, useCallback, useState } from 'react'
+
+interface SwipeHandlers {
+  onSwipeLeft?: () => void
+  onSwipeRight?: () => void
+  onSwipeUp?: () => void
+  onSwipeDown?: () => void
+}
+
+interface TouchState {
+  startX: number
+  startY: number
+  startTime: number
+}
+
+export function useSwipe(handlers: SwipeHandlers, threshold = 50) {
+  const touchRef = useRef<TouchState | null>(null)
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0]
+    touchRef.current = {
+      startX: touch.clientX,
+      startY: touch.clientY,
+      startTime: Date.now(),
+    }
+  }, [])
+
+  const onTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (!touchRef.current) return
+    const touch = e.changedTouches[0]
+    const dx = touch.clientX - touchRef.current.startX
+    const dy = touch.clientY - touchRef.current.startY
+    const dt = Date.now() - touchRef.current.startTime
+
+    if (dt > 500) return
+
+    const absDx = Math.abs(dx)
+    const absDy = Math.abs(dy)
+
+    if (absDx > absDy && absDx > threshold) {
+      if (dx > 0) handlers.onSwipeRight?.()
+      else handlers.onSwipeLeft?.()
+    } else if (absDy > absDx && absDy > threshold) {
+      if (dy > 0) handlers.onSwipeDown?.()
+      else handlers.onSwipeUp?.()
+    }
+
+    touchRef.current = null
+  }, [handlers, threshold])
+
+  return { onTouchStart, onTouchEnd }
+}
+
+interface BottomSheetProps {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: React.ReactNode
+}
+
+export function BottomSheet({ open, onClose, title, children }: BottomSheetProps) {
+  const [dragging, setDragging] = useState(false)
+  const [translateY, setTranslateY] = useState(0)
+  const startYRef = useRef(0)
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    startYRef.current = e.touches[0].clientY
+    setDragging(true)
+  }, [])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!dragging) return
+    const dy = e.touches[0].clientY - startYRef.current
+    if (dy > 0) setTranslateY(dy)
+  }, [dragging])
+
+  const handleTouchEnd = useCallback(() => {
+    setDragging(false)
+    if (translateY > 100) {
+      onClose()
+    }
+    setTranslateY(0)
+  }, [translateY, onClose])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed bottom-0 left-0 right-0 z-50 bg-surface rounded-t-2xl border-t border-border max-h-[80vh] overflow-hidden animate-slide-up"
+        style={{ transform: `translateY(${translateY}px)`, transition: dragging ? 'none' : 'transform 0.2s ease-out' }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div
+          className="flex justify-center py-3 cursor-grab active:cursor-grabbing"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className="w-10 h-1 rounded-full bg-border-2" aria-hidden="true" />
+        </div>
+        {title && (
+          <div className="px-5 pb-3 border-b border-border">
+            <h2 className="text-sm font-medium">{title}</h2>
+          </div>
+        )}
+        <div className="overflow-auto p-5 max-h-[calc(80vh-4rem)]">
+          {children}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/line/web/src/index.css
+++ b/line/web/src/index.css
@@ -18,6 +18,23 @@
   --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace;
 }
 
+[data-theme="light"] {
+  --color-bg: #f8f9fa;
+  --color-surface: #ffffff;
+  --color-surface-2: #f0f1f3;
+  --color-border: #e0e0e0;
+  --color-border-2: #ccc;
+  --color-text: #1a1a1a;
+  --color-text-muted: #666;
+  --color-text-dim: #999;
+  --color-accent: #0288d1;
+  --color-accent-dim: #e1f5fe;
+  --color-green: #2e7d32;
+  --color-red: #c62828;
+  --color-orange: #e64a19;
+  --color-yellow: #f9a825;
+}
+
 body {
   @apply bg-bg text-text antialiased;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
@@ -26,4 +43,61 @@ body {
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-2) transparent;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slide-in-right {
+  from { opacity: 0; transform: translateX(8px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(100%); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.2s ease-out both;
+}
+
+.animate-slide-in {
+  animation: slide-in-right 0.2s ease-out both;
+}
+
+.animate-scale-in {
+  animation: scale-in 0.15s ease-out both;
+}
+
+.animate-slide-up {
+  animation: slide-up 0.25s ease-out both;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  z-index: 100;
+  padding: 8px 16px;
+  background: var(--color-accent);
+  color: white;
+  transition: top 0.2s;
+}
+
+.skip-link:focus {
+  top: 0;
 }

--- a/line/web/src/main.tsx
+++ b/line/web/src/main.tsx
@@ -1,36 +1,51 @@
-import { StrictMode } from 'react'
+import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router'
 import './index.css'
 import { App } from './App'
-import { SessionsPage } from './pages/Sessions'
-import { SessionDetail } from './pages/SessionDetail'
-import { ReplayPage } from './pages/Replay'
-import { BriefingPage } from './pages/Briefing'
-import { LivePage } from './pages/Live'
-import { ProgressionPage } from './pages/Progression'
-import { TracksPage } from './pages/Tracks'
-import { ReferenceLapsPage } from './pages/ReferenceLaps'
-import { ComparePage } from './pages/Compare'
+import { ErrorBoundary } from './components/ErrorBoundary'
+import { ThemeProvider } from './components/ThemeProvider'
+
+const SessionsPage = lazy(() => import('./pages/Sessions').then(m => ({ default: m.SessionsPage })))
+const SessionDetail = lazy(() => import('./pages/SessionDetail').then(m => ({ default: m.SessionDetail })))
+const ReplayPage = lazy(() => import('./pages/Replay').then(m => ({ default: m.ReplayPage })))
+const BriefingPage = lazy(() => import('./pages/Briefing').then(m => ({ default: m.BriefingPage })))
+const LivePage = lazy(() => import('./pages/Live').then(m => ({ default: m.LivePage })))
+const ProgressionPage = lazy(() => import('./pages/Progression').then(m => ({ default: m.ProgressionPage })))
+const TracksPage = lazy(() => import('./pages/Tracks').then(m => ({ default: m.TracksPage })))
+const ReferenceLapsPage = lazy(() => import('./pages/ReferenceLaps').then(m => ({ default: m.ReferenceLapsPage })))
+const ComparePage = lazy(() => import('./pages/Compare').then(m => ({ default: m.ComparePage })))
+
+function PageLoader() {
+  return (
+    <div className="flex items-center justify-center h-full" role="status" aria-label="Loading page">
+      <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<App />}>
-          <Route index element={<SessionsPage />} />
-          <Route path="sessions" element={<SessionsPage />} />
-          <Route path="sessions/:id" element={<SessionDetail />} />
-          <Route path="sessions/:id/replay" element={<ReplayPage />} />
-          <Route path="sessions/:id/briefing" element={<BriefingPage />} />
-          <Route path="live" element={<LivePage />} />
-          <Route path="progression" element={<ProgressionPage />} />
-          <Route path="tracks" element={<TracksPage />} />
-          <Route path="reference" element={<ReferenceLapsPage />} />
-          <Route path="compare" element={<ComparePage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <ErrorBoundary>
+        <BrowserRouter>
+          <Routes>
+            <Route element={<App />}>
+              <Route index element={<Suspense fallback={<PageLoader />}><SessionsPage /></Suspense>} />
+              <Route path="sessions" element={<Suspense fallback={<PageLoader />}><SessionsPage /></Suspense>} />
+              <Route path="sessions/:id" element={<Suspense fallback={<PageLoader />}><SessionDetail /></Suspense>} />
+              <Route path="sessions/:id/replay" element={<Suspense fallback={<PageLoader />}><ReplayPage /></Suspense>} />
+              <Route path="sessions/:id/briefing" element={<Suspense fallback={<PageLoader />}><BriefingPage /></Suspense>} />
+              <Route path="live" element={<Suspense fallback={<PageLoader />}><LivePage /></Suspense>} />
+              <Route path="progression" element={<Suspense fallback={<PageLoader />}><ProgressionPage /></Suspense>} />
+              <Route path="tracks" element={<Suspense fallback={<PageLoader />}><TracksPage /></Suspense>} />
+              <Route path="reference" element={<Suspense fallback={<PageLoader />}><ReferenceLapsPage /></Suspense>} />
+              <Route path="compare" element={<Suspense fallback={<PageLoader />}><ComparePage /></Suspense>} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </ErrorBoundary>
+    </ThemeProvider>
   </StrictMode>,
 )
 

--- a/line/web/src/pages/Live.tsx
+++ b/line/web/src/pages/Live.tsx
@@ -14,6 +14,7 @@ export function LivePage() {
   const [coachMessages, setCoachMessages] = useState<CoachMessage[]>([])
   const [cars, setCars] = useState<Car[]>([])
   const [coachEnabled, setCoachEnabled] = useState(true)
+  const [connected, setConnected] = useState(false)
   const wsRef = useRef<WebSocket | null>(null)
   const coachRef = useRef<WebSocket | null>(null)
   const audioCtxRef = useRef<AudioContext | null>(null)
@@ -46,6 +47,8 @@ export function LivePage() {
       },
       (s) => setStatus(s),
     )
+    ws.onopen = () => setConnected(true)
+    ws.onclose = () => setConnected(false)
     wsRef.current = ws
     return () => ws.close()
   }, [])
@@ -66,20 +69,28 @@ export function LivePage() {
 
   return (
     <div className="flex flex-col-reverse md:flex-row h-full">
-      <div className="flex-1 min-h-0 bg-surface">
+      <div className="flex-1 min-h-0 bg-surface relative" role="img" aria-label="Live track visualization">
         <Canvas camera={{ position: [0, 200, 200], fov: 60 }}>
           <ambientLight intensity={0.4} />
           <directionalLight position={[100, 200, 100]} intensity={0.8} />
           {frames.length > 1 && <LiveTrail frames={frames} />}
-          <gridHelper args={[800, 40, '#333333', '#222222']} />
+          <gridHelper args={[800, 40, '#333', '#222222']} />
           <OrbitControls enableDamping dampingFactor={0.1} maxPolarAngle={Math.PI / 2.1} />
         </Canvas>
+        {!connected && (
+          <div className="absolute inset-0 flex items-center justify-center bg-bg/80 backdrop-blur-sm animate-fade-in">
+            <div className="text-center space-y-2">
+              <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin mx-auto" />
+              <p className="text-xs text-text-muted">Connecting to live feed...</p>
+            </div>
+          </div>
+        )}
       </div>
-      <aside className="w-full md:w-72 border-b md:border-b-0 md:border-l border-border p-4 overflow-auto flex flex-col gap-5 max-h-64 md:max-h-none">
+      <aside className="w-full md:w-72 border-b md:border-b-0 md:border-l border-border p-4 overflow-auto flex flex-col gap-5 max-h-64 md:max-h-none" aria-label="Live telemetry sidebar">
         <StatusBadge active={status.active} />
 
         {status.active && (
-          <div className="text-xs text-text-muted space-y-1">
+          <div className="text-xs text-text-muted space-y-1 animate-fade-in">
             <div>Car: <span className="text-text font-mono">{getCarName(cars, status.car_code ?? 0)}</span></div>
             <div>Lap: <span className="text-text font-mono">{status.current_lap}</span></div>
             {status.track_id && <div>Track: <span className="text-text">{status.track_id}</span></div>}
@@ -87,7 +98,7 @@ export function LivePage() {
         )}
 
         {latest && (
-          <div>
+          <div className="animate-fade-in" aria-label="Current telemetry values" role="region">
             <h3 className="text-xs font-medium text-text-muted mb-3 uppercase tracking-wider">Telemetry</h3>
             <div className="space-y-2">
               <Gauge label="Speed" value={latest.speed} unit="km/h" max={350} color="bg-accent" />
@@ -95,8 +106,8 @@ export function LivePage() {
               <Gauge label="Throttle" value={latest.throttle * 100} unit="%" max={100} color="bg-green" />
               <Gauge label="Brake" value={latest.brake * 100} unit="%" max={100} color="bg-red" />
             </div>
-            <div className="mt-3 text-center">
-              <span className="text-3xl font-mono font-bold text-text">{latest.gear}</span>
+            <div className="mt-3 text-center" aria-label={`Gear ${latest.gear}`}>
+              <span className="text-3xl font-mono font-bold text-text transition-all duration-75">{latest.gear}</span>
               <span className="text-xs text-text-muted ml-1">gear</span>
             </div>
           </div>
@@ -107,20 +118,22 @@ export function LivePage() {
             <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider">Coach</h3>
             <button
               onClick={() => setCoachEnabled((v) => !v)}
+              aria-pressed={coachEnabled}
+              aria-label={`Coach ${coachEnabled ? 'enabled' : 'disabled'}`}
               className={clsx(
-                'px-2 py-0.5 rounded text-xs font-medium transition-colors',
+                'px-2 py-0.5 rounded text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50',
                 coachEnabled ? 'bg-green text-white' : 'bg-border-2 text-text-muted',
               )}
             >
               {coachEnabled ? 'ON' : 'OFF'}
             </button>
           </div>
-          <div className="space-y-2 max-h-48 overflow-auto">
+          <div className="space-y-2 max-h-48 overflow-auto" role="log" aria-label="Coach messages" aria-live="polite">
             {coachMessages.length === 0 && (
               <p className="text-xs text-text-dim">Waiting for coaching events...</p>
             )}
             {coachMessages.map((msg, i) => (
-              <div key={i} className="text-xs text-text-muted border-l-2 border-accent pl-2">
+              <div key={i} className="text-xs text-text-muted border-l-2 border-accent pl-2 animate-slide-in">
                 <div className="text-text">{msg.text}</div>
                 <div className="text-text-dim mt-0.5">{msg.latency_ms}ms</div>
               </div>
@@ -156,11 +169,11 @@ function LiveTrail({ frames }: { frames: TelemetryFrame[] }) {
 
 function StatusBadge({ active }: { active: boolean }) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2" role="status" aria-label={active ? 'Session active' : 'Waiting for session'}>
       <div className={clsx(
-        'w-2.5 h-2.5 rounded-full',
-        active ? 'bg-green shadow-[0_0_8px_var(--color-green)]' : 'bg-text-dim',
-      )} />
+        'w-2.5 h-2.5 rounded-full transition-colors',
+        active ? 'bg-green shadow-[0_0_8px_var(--color-green)] animate-pulse' : 'bg-text-dim',
+      )} aria-hidden="true" />
       <span className={clsx('text-sm', active ? 'text-green' : 'text-text-dim')}>
         {active ? 'Live' : 'Waiting for session'}
       </span>
@@ -171,7 +184,7 @@ function StatusBadge({ active }: { active: boolean }) {
 function Gauge({ label, value, unit, max, color }: { label: string; value: number; unit: string; max: number; color: string }) {
   const pct = Math.min(100, (value / max) * 100)
   return (
-    <div>
+    <div role="meter" aria-label={label} aria-valuenow={Math.round(value)} aria-valuemin={0} aria-valuemax={max}>
       <div className="flex justify-between text-xs mb-0.5">
         <span className="text-text-muted">{label}</span>
         <span className="text-text font-mono">{Math.round(value)}{unit && ` ${unit}`}</span>

--- a/line/web/src/pages/Progression.tsx
+++ b/line/web/src/pages/Progression.tsx
@@ -124,7 +124,7 @@ export function ProgressionPage() {
                 <Tooltip
                   contentStyle={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)', borderRadius: '6px', fontSize: '11px' }}
                   formatter={(value: unknown) => [`${Number(value).toFixed(3)}s`, 'Best Lap']}
-                  labelFormatter={(label: string) => label}
+                  labelFormatter={(label) => String(label)}
                 />
                 <Line type="monotone" dataKey="bestLap" stroke="var(--color-accent)" dot={{ r: 3, fill: 'var(--color-accent)' }} strokeWidth={2} />
               </LineChart>

--- a/line/web/src/pages/SessionDetail.tsx
+++ b/line/web/src/pages/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useParams, Link } from 'react-router'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Line } from '@react-three/drei'
@@ -6,6 +6,11 @@ import * as THREE from 'three'
 import clsx from 'clsx'
 import { fetchLaps, fetchTelemetry, fetchLapMetrics, fetchSessionSummary, fetchSession, fetchReferenceLapTelemetry, setReferenceLap, fetchJournal, generateJournal, fetchLapBraking, fetchLapStability, fetchRacingLine, fetchFatigue, fetchTimeDeltas, type Lap, type TelemetryFrame, type LapMetrics, type SessionSummary, type Journal, type BrakingAnalysis, type StabilityAnalysis, type RacingLineAnalysis, type FatigueAnalysis, type TimeDeltaEntry } from '../api'
 import { TelemetryChart } from '../TelemetryChart'
+import { LapListSkeleton, ChartSkeleton, MetricCardSkeleton } from '../components/Skeleton'
+import { useSwipe } from '../hooks/useSwipe'
+
+const TABS = ['track', 'metrics', 'analytics', 'summary', 'journal'] as const
+type Tab = typeof TABS[number]
 
 export function SessionDetail() {
   const { id } = useParams<{ id: string }>()
@@ -18,7 +23,8 @@ export function SessionDetail() {
   const [metrics, setMetrics] = useState<LapMetrics | null>(null)
   const [summary, setSummary] = useState<SessionSummary | null>(null)
   const [loading, setLoading] = useState(true)
-  const [tab, setTab] = useState<'track' | 'metrics' | 'analytics' | 'summary' | 'journal'>('track')
+  const [telemetryLoading, setTelemetryLoading] = useState(false)
+  const [tab, setTab] = useState<Tab>('track')
   const [session, setSession] = useState<{ car_code: number; track_id?: string } | null>(null)
   const [refSaving, setRefSaving] = useState(false)
   const [journal, setJournal] = useState<Journal | null>(null)
@@ -53,10 +59,13 @@ export function SessionDetail() {
 
   useEffect(() => {
     if (!id || selectedLap === null) return
-    fetchTelemetry(id, selectedLap, 2).then(({ frames }) => setFrames(frames ?? []))
-    fetchLapMetrics(id, selectedLap).then(setMetrics).catch(() => setMetrics(null))
-    fetchLapBraking(id, selectedLap).then(setBraking).catch(() => setBraking(null))
-    fetchLapStability(id, selectedLap).then(setStability).catch(() => setStability(null))
+    setTelemetryLoading(true)
+    Promise.all([
+      fetchTelemetry(id, selectedLap, 2).then(({ frames }) => setFrames(frames ?? [])),
+      fetchLapMetrics(id, selectedLap).then(setMetrics).catch(() => setMetrics(null)),
+      fetchLapBraking(id, selectedLap).then(setBraking).catch(() => setBraking(null)),
+      fetchLapStability(id, selectedLap).then(setStability).catch(() => setStability(null)),
+    ]).finally(() => setTelemetryLoading(false))
   }, [id, selectedLap])
 
   useEffect(() => {
@@ -68,10 +77,37 @@ export function SessionDetail() {
     if (compareLap === null) setCompareFrames([])
   }, [compareLap])
 
+  const handleTabKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const idx = TABS.indexOf(tab)
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      setTab(TABS[(idx + 1) % TABS.length])
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      setTab(TABS[(idx - 1 + TABS.length) % TABS.length])
+    }
+  }, [tab])
+
+  const swipeHandlers = useSwipe({
+    onSwipeLeft: () => {
+      const idx = TABS.indexOf(tab)
+      if (idx < TABS.length - 1) setTab(TABS[idx + 1])
+    },
+    onSwipeRight: () => {
+      const idx = TABS.indexOf(tab)
+      if (idx > 0) setTab(TABS[idx - 1])
+    },
+  })
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+      <div className="flex flex-col md:flex-row h-full">
+        <aside className="w-full md:w-52 border-b md:border-b-0 md:border-r border-border">
+          <LapListSkeleton />
+        </aside>
+        <div className="flex-1 p-4">
+          <ChartSkeleton />
+        </div>
       </div>
     )
   }
@@ -80,19 +116,23 @@ export function SessionDetail() {
 
   return (
     <div className="flex flex-col md:flex-row h-full">
-      <aside className="w-full md:w-52 border-b md:border-b-0 md:border-r border-border overflow-auto p-3 flex md:flex-col gap-1 max-h-24 md:max-h-none">
+      <aside className="w-full md:w-52 border-b md:border-b-0 md:border-r border-border overflow-auto p-3 flex md:flex-col gap-1 max-h-24 md:max-h-none" aria-label="Lap list" role="listbox" aria-activedescendant={selectedLap !== null ? `lap-${selectedLap}` : undefined}>
         <h3 className="hidden md:block text-xs font-medium text-text-muted uppercase tracking-wider mb-2">Laps</h3>
         {laps.length === 0 && <p className="text-xs text-text-dim">No laps yet</p>}
         {laps.map((lap) => (
           <button
             key={lap.lap_number}
+            id={`lap-${lap.lap_number}`}
+            role="option"
+            aria-selected={selectedLap === lap.lap_number}
+            aria-label={`Lap ${lap.lap_number}, ${formatLapTime(lap.time_ms)}${lap.lap_number === bestLap?.lap_number ? ', best lap' : ''}`}
             onClick={() => setSelectedLap(lap.lap_number)}
             onContextMenu={(e) => {
               e.preventDefault()
               setCompareLap(compareLap === lap.lap_number ? null : lap.lap_number)
             }}
             className={clsx(
-              'flex justify-between items-center w-full px-2.5 py-1.5 rounded text-xs transition-colors text-left',
+              'flex justify-between items-center w-full px-2.5 py-1.5 rounded text-xs transition-all duration-150 text-left',
               selectedLap === lap.lap_number
                 ? 'bg-accent-dim border border-accent/50 text-text'
                 : compareLap === lap.lap_number
@@ -101,7 +141,7 @@ export function SessionDetail() {
             )}
           >
             <span className="flex items-center gap-1.5">
-              {lap.lap_number === bestLap?.lap_number && <span className="text-yellow text-[10px]">&#9733;</span>}
+              {lap.lap_number === bestLap?.lap_number && <span className="text-yellow text-[10px]" aria-hidden="true">&#9733;</span>}
               Lap {lap.lap_number}
             </span>
             <span className={clsx(
@@ -113,18 +153,22 @@ export function SessionDetail() {
           </button>
         ))}
         {laps.length > 1 && (
-          <p className="text-[10px] text-text-dim mt-2 px-1">Right-click a lap to compare</p>
+          <p className="text-[10px] text-text-dim mt-2 px-1" aria-hidden="true">Right-click a lap to compare</p>
         )}
       </aside>
 
-      <div className="flex-1 flex flex-col min-w-0">
-        <div className="flex items-center gap-1 px-4 py-2 border-b border-border">
-          {(['track', 'metrics', 'analytics', 'summary', 'journal'] as const).map((t) => (
+      <div className="flex-1 flex flex-col min-w-0" {...swipeHandlers}>
+        <div className="flex items-center gap-1 px-4 py-2 border-b border-border overflow-x-auto" role="tablist" aria-label="Session detail tabs" onKeyDown={handleTabKeyDown}>
+          {TABS.map((t) => (
             <button
               key={t}
+              role="tab"
+              aria-selected={tab === t}
+              aria-controls={`tabpanel-${t}`}
+              tabIndex={tab === t ? 0 : -1}
               onClick={() => setTab(t)}
               className={clsx(
-                'px-3 py-1 rounded text-xs font-medium transition-colors capitalize',
+                'px-3 py-1 rounded text-xs font-medium transition-all duration-150 capitalize whitespace-nowrap',
                 tab === t ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text',
               )}
             >
@@ -134,14 +178,14 @@ export function SessionDetail() {
           {selectedLap !== null && (
             <Link
               to={`/sessions/${id}/replay?lap=${selectedLap}`}
-              className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-accent transition-colors"
+              className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-accent transition-colors whitespace-nowrap"
             >
               Replay
             </Link>
           )}
           <Link
             to={`/sessions/${id}/briefing`}
-            className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-accent transition-colors"
+            className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-accent transition-colors whitespace-nowrap"
           >
             Briefing
           </Link>
@@ -168,25 +212,31 @@ export function SessionDetail() {
                 setRefSaving(false)
               }}
               disabled={refSaving}
-              className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-green transition-colors disabled:opacity-50"
+              className="px-3 py-1 rounded text-xs font-medium text-text-muted hover:text-green transition-colors disabled:opacity-50 whitespace-nowrap"
+              aria-label="Set current lap as reference"
             >
               {refSaving ? 'Saving...' : 'Set as Reference'}
             </button>
           )}
           {refFrames.length > 0 && (
-            <span className="text-[10px] text-green ml-1">ref loaded</span>
+            <span className="text-[10px] text-green ml-1" aria-label="Reference lap loaded">ref loaded</span>
           )}
           {compareLap !== null && (
-            <span className="ml-auto text-xs text-orange">
+            <span className="ml-auto text-xs text-orange whitespace-nowrap">
               Comparing with Lap {compareLap}
-              <button onClick={() => setCompareLap(null)} className="ml-2 text-text-dim hover:text-text">&times;</button>
+              <button onClick={() => setCompareLap(null)} className="ml-2 text-text-dim hover:text-text" aria-label="Clear comparison">&times;</button>
             </span>
           )}
         </div>
 
         {tab === 'track' && (
-          <div className="flex-1 flex flex-col min-h-0">
-            <div className="flex-1 min-h-0 bg-surface">
+          <div id="tabpanel-track" role="tabpanel" aria-labelledby="tab-track" className="flex-1 flex flex-col min-h-0 animate-fade-in">
+            <div className="flex-1 min-h-0 bg-surface relative" aria-label="3D track visualization">
+              {telemetryLoading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-bg/60 backdrop-blur-sm z-10">
+                  <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
               <Canvas camera={{ position: [0, 200, 200], fov: 60 }}>
                 <ambientLight intensity={0.4} />
                 <directionalLight position={[100, 200, 100]} intensity={0.8} />
@@ -203,40 +253,44 @@ export function SessionDetail() {
           </div>
         )}
 
-        {tab === 'metrics' && metrics && (
-          <div className="flex-1 overflow-auto p-5">
-            <MetricsPanel metrics={metrics} />
-          </div>
-        )}
-
-        {tab === 'metrics' && !metrics && (
-          <div className="flex-1 flex items-center justify-center text-text-dim text-sm">
-            No metrics available for this lap
+        {tab === 'metrics' && (
+          <div id="tabpanel-metrics" role="tabpanel" aria-labelledby="tab-metrics" className="flex-1 overflow-auto p-5 animate-fade-in">
+            {telemetryLoading ? (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                {Array.from({ length: 8 }).map((_, i) => <MetricCardSkeleton key={i} />)}
+              </div>
+            ) : metrics ? (
+              <MetricsPanel metrics={metrics} />
+            ) : (
+              <div className="flex items-center justify-center h-40 text-text-dim text-sm">
+                No metrics available for this lap
+              </div>
+            )}
           </div>
         )}
 
         {tab === 'analytics' && (
-          <div className="flex-1 overflow-auto p-5">
+          <div id="tabpanel-analytics" role="tabpanel" aria-labelledby="tab-analytics" className="flex-1 overflow-auto p-5 animate-fade-in">
             <AnalyticsPanel braking={braking} stability={stability} racingLine={racingLine} fatigue={fatigue} timeDeltas={timeDeltas} />
           </div>
         )}
 
-        {tab === 'summary' && summary && (
-          <div className="flex-1 overflow-auto p-5">
-            <SummaryPanel summary={summary} />
-          </div>
-        )}
-
-        {tab === 'summary' && !summary && (
-          <div className="flex-1 flex items-center justify-center text-text-dim text-sm">
-            No session summary available yet
+        {tab === 'summary' && (
+          <div id="tabpanel-summary" role="tabpanel" aria-labelledby="tab-summary" className="flex-1 overflow-auto p-5 animate-fade-in">
+            {summary ? (
+              <SummaryPanel summary={summary} />
+            ) : (
+              <div className="flex items-center justify-center h-40 text-text-dim text-sm">
+                No session summary available yet
+              </div>
+            )}
           </div>
         )}
 
         {tab === 'journal' && (
-          <div className="flex-1 overflow-auto p-5">
+          <div id="tabpanel-journal" role="tabpanel" aria-labelledby="tab-journal" className="flex-1 overflow-auto p-5 animate-fade-in">
             {journal ? (
-              <div className="bg-surface-2 rounded-lg border border-border p-5">
+              <div className="bg-surface-2 rounded-lg border border-border p-5 animate-scale-in">
                 <div className="flex items-center justify-between mb-4">
                   <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider">Session Journal</h4>
                   <span className="text-[10px] text-text-dim">{new Date(journal.created_at).toLocaleString()}</span>
@@ -259,7 +313,8 @@ export function SessionDetail() {
                     setJournalLoading(false)
                   }}
                   disabled={journalLoading}
-                  className="px-4 py-2 rounded-lg bg-accent/15 text-accent text-sm font-medium hover:bg-accent/25 transition-colors disabled:opacity-50"
+                  className="px-4 py-2 rounded-lg bg-accent/15 text-accent text-sm font-medium hover:bg-accent/25 transition-colors disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-accent/50"
+                  aria-label="Generate session journal using AI"
                 >
                   {journalLoading ? 'Generating...' : 'Generate Journal'}
                 </button>

--- a/line/web/src/pages/Sessions.tsx
+++ b/line/web/src/pages/Sessions.tsx
@@ -1,32 +1,53 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 import { fetchSessions, fetchCars, getCarName, type Session, type Car } from '../api'
+import { SessionCardSkeleton } from '../components/Skeleton'
 
 export function SessionsPage() {
   const [sessions, setSessions] = useState<Session[]>([])
   const [cars, setCars] = useState<Car[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     Promise.all([fetchSessions(), fetchCars()]).then(([{ sessions }, cars]) => {
       setSessions(sessions ?? [])
       setCars(cars)
       setLoading(false)
-    }).catch(() => setLoading(false))
+    }).catch((err) => {
+      setError(err.message || 'Failed to load sessions')
+      setLoading(false)
+    })
   }, [])
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+      <div className="p-5 space-y-2" aria-label="Loading sessions" role="status">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <SessionCardSkeleton key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 p-8" role="alert">
+        <p className="text-sm text-red">{error}</p>
+        <button
+          onClick={() => { setLoading(true); setError(null); window.location.reload() }}
+          className="px-4 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50"
+        >
+          Retry
+        </button>
       </div>
     )
   }
 
   if (sessions.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-3 text-text-muted">
-        <div className="text-4xl opacity-30">&#127937;</div>
+      <div className="flex flex-col items-center justify-center h-full gap-3 text-text-muted animate-fade-in">
+        <div className="text-4xl opacity-30" aria-hidden="true">&#127937;</div>
         <p className="text-sm">No sessions recorded yet.</p>
         <p className="text-xs text-text-dim">Start a race in GT7 to begin capturing telemetry.</p>
       </div>
@@ -37,14 +58,17 @@ export function SessionsPage() {
     <div className="p-5 overflow-auto h-full">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-base font-medium">Sessions</h2>
-        <span className="text-xs text-text-muted">{sessions.length} total</span>
+        <span className="text-xs text-text-muted" aria-label={`${sessions.length} total sessions`}>{sessions.length} total</span>
       </div>
-      <div className="flex flex-col gap-2">
-        {sessions.map((s) => (
+      <div className="flex flex-col gap-2" role="list" aria-label="Session list">
+        {sessions.map((s, i) => (
           <Link
             key={s.id}
             to={`/sessions/${s.id}`}
-            className="flex justify-between items-center p-4 bg-surface-2 rounded-lg border border-border hover:border-accent/40 transition-colors group"
+            className="flex justify-between items-center p-4 bg-surface-2 rounded-lg border border-border hover:border-accent/40 transition-all duration-200 group animate-fade-in hover:translate-x-0.5"
+            style={{ animationDelay: `${i * 30}ms` }}
+            role="listitem"
+            aria-label={`${s.track_id || 'Unknown Track'}, ${getCarName(cars, s.car_code)}, best lap ${formatLapTime(s.best_lap_ms)}`}
           >
             <div>
               <div className="font-medium text-sm group-hover:text-accent transition-colors">

--- a/line/web/src/recharts.d.ts
+++ b/line/web/src/recharts.d.ts
@@ -7,6 +7,9 @@ declare module 'recharts' {
     width?: number
     height?: number
     margin?: { top?: number; right?: number; bottom?: number; left?: number }
+    onMouseDown?: (e: unknown) => void
+    onMouseMove?: (e: unknown) => void
+    onMouseUp?: (e: unknown) => void
   }
   export const LineChart: FC<LineChartProps>
 
@@ -18,6 +21,7 @@ declare module 'recharts' {
     strokeWidth?: number
     strokeDasharray?: string
     opacity?: number
+    animationDuration?: number
   }
   export const Line: FC<LineProps>
 
@@ -50,7 +54,7 @@ declare module 'recharts' {
   export interface TooltipProps {
     contentStyle?: object
     formatter?: (...args: unknown[]) => unknown
-    labelFormatter?: (label: string) => string
+    labelFormatter?: (label: string | number) => string
   }
   export const Tooltip: FC<TooltipProps>
 
@@ -60,6 +64,18 @@ declare module 'recharts' {
     children?: React.ReactNode
   }
   export const ResponsiveContainer: FC<ResponsiveContainerProps>
+
+  export interface ReferenceAreaProps {
+    x1?: string | number
+    x2?: string | number
+    y1?: string | number
+    y2?: string | number
+    stroke?: string
+    strokeOpacity?: number
+    fill?: string
+    fillOpacity?: number
+  }
+  export const ReferenceArea: FC<ReferenceAreaProps>
 
   export interface ScatterChartProps {
     data?: unknown[]


### PR DESCRIPTION
## Summary

- Error boundaries with retry, skeleton loaders for all loading states
- Dark/light/system theme toggle with CSS custom properties
- Full accessibility pass: ARIA roles, keyboard navigation (arrow keys for tabs), focus-visible, skip link, screen reader labels
- Animations: fade-in, slide-in, scale-in for page transitions and state changes
- Mobile UX: swipe between tabs, bottom sheet component, touch gesture hooks
- Chart zoom: drag-to-zoom on telemetry charts with reset button
- Themed chart colors using CSS variables (works in both themes)
- Telemetry loading overlay on 3D canvas during lap switch