### PR TITLE
fix(nodepool-autoscaler): build fix and ready-node scaling

### DIFF
--- a/nodepool-autoscaler/BUILD.bazel
+++ b/nodepool-autoscaler/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         ":api_lib",
         ":controller_lib",
         ":metrics_lib",
+        "@com_github_go_logr_logr//:logr",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/util/runtime",
@@ -99,6 +100,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/healthz",
+        "@io_k8s_sigs_controller_runtime//pkg/log",
         "@io_k8s_sigs_controller_runtime//pkg/metrics/server",
     ],
 )

--- a/nodepool-autoscaler/internal/controller/autoscaler.go
+++ b/nodepool-autoscaler/internal/controller/autoscaler.go
@@ -77,6 +77,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	maxSizeField := nodepool.ParseFieldPath(scaler.Spec.TargetRef.MaxSizeField)
 
 	currentSize, _ := nodepool.GetFieldInt64(obj, sizeField)
+	readyNodes, err := r.countReadyNodes(ctx, scaler.Spec.Selector)
+	if err != nil {
+		r.Log.Error("counting ready nodes", "error", err, "scaler", req.NamespacedName)
+		return ctrl.Result{RequeueAfter: reconcileInterval}, nil
+	}
+	metrics.ReadyNodes.WithLabelValues(req.String()).Set(float64(readyNodes))
+
 	maxSize := scaler.Spec.Scaling.MaxSize
 	if scaler.Spec.TargetRef.MaxSizeField != "" {
 		if crMax, ok := nodepool.GetFieldInt64(obj, maxSizeField); ok && crMax < maxSize {
@@ -113,8 +120,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			desired = 1
 		}
 
-		if desired > currentSize {
-			r.Log.Info("scaling up", "current", currentSize, "desired", desired, "pending_pods", len(pendingPods), "scaler", req.NamespacedName)
+		if desired > readyNodes {
+			newTarget := desired
+			if currentSize > newTarget {
+				newTarget = currentSize
+			}
+			r.Log.Info("scaling up", "current", currentSize, "ready_nodes", readyNodes, "desired", newTarget, "pending_pods", len(pendingPods), "scaler", req.NamespacedName)
 			tc := nodepool.TargetConfig{
 				Group:     targetGVK.Group,
 				Version:   targetGVK.Version,
@@ -123,11 +134,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Namespace: scaler.Spec.TargetRef.Namespace,
 				SizeField: sizeField,
 			}
-			if err := nodepool.PatchTargetSize(ctx, r.Client, tc, desired); err != nil {
+			if err := nodepool.PatchTargetSize(ctx, r.Client, tc, newTarget); err != nil {
 				r.Log.Error("patching target size", "error", err)
 				return ctrl.Result{RequeueAfter: reconcileInterval}, nil
 			}
-			metrics.TargetSize.WithLabelValues(req.String()).Set(float64(desired))
+			metrics.TargetSize.WithLabelValues(req.String()).Set(float64(newTarget))
 			metrics.ScaleUpTotal.WithLabelValues(req.String()).Inc()
 			metrics.LastScaleUpTime.WithLabelValues(req.String()).Set(float64(now.Unix()))
 
@@ -308,6 +319,28 @@ func isUnschedulable(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+func (r *Reconciler) countReadyNodes(ctx context.Context, selector v1alpha1.PodSelector) (int64, error) {
+	var nodeList corev1.NodeList
+	opts := []client.ListOption{}
+	if len(selector.NodeSelector) > 0 {
+		opts = append(opts, client.MatchingLabels(selector.NodeSelector))
+	}
+	if err := r.List(ctx, &nodeList, opts...); err != nil {
+		return 0, err
+	}
+
+	var count int64
+	for _, node := range nodeList.Items {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
 }
 
 func parseGVK(ref v1alpha1.TargetRef) schema.GroupVersionKind {

--- a/nodepool-autoscaler/internal/metrics/metrics.go
+++ b/nodepool-autoscaler/internal/metrics/metrics.go
@@ -35,6 +35,11 @@ var (
 		Name: "nodepool_autoscaler_idle_seconds",
 		Help: "Seconds since last pod activity",
 	}, []string{"scaler"})
+
+	ReadyNodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "nodepool_autoscaler_ready_nodes",
+		Help: "Number of ready nodes matching the selector",
+	}, []string{"scaler"})
 )
 
 func init() {
@@ -45,5 +50,6 @@ func init() {
 		ScaleDownTotal,
 		LastScaleUpTime,
 		IdleSeconds,
+		ReadyNodes,
 	)
 }


### PR DESCRIPTION
## Summary

Two fixes for the nodepool-autoscaler:

### 1. Build fix
Added missing deps `@com_github_go_logr_logr//:logr` and `@io_k8s_sigs_controller_runtime//pkg/log` to the `lib` target.

### 2. Scale-up logic fix
The controller compared `desired` against `spec.targetSize` from the CR, not actual ready nodes. When spot instances are preempted and nodes disappear (but MIG reports stable), the controller never triggers a scale-up.

Now counts actual ready nodes matching the selector. If `desired > readyNodes`, patches the target (using `max(desired, currentSize)` to avoid reducing below what was already requested).

Adds `nodepool_autoscaler_ready_nodes` Prometheus metric.

## Testing

- `bazel build //nodepool-autoscaler:image` — passes
- `bazel test //nodepool-autoscaler:controller_test //nodepool-autoscaler:nodepool_test` — passes