### PR TITLE
feat(scrib): audio quality optimizations

### DIFF
--- a/scrib/audio/recorder_test.go
+++ b/scrib/audio/recorder_test.go
@@ -132,6 +132,8 @@ func TestTimestampAlignmentWithOffset(t *testing.T) {
 	r := &Recorder{sampleRate: 16000}
 	r.mu.Lock()
 	r.recording = true
+	r.sysReady = true
+	r.sysAnchor = 1.0
 	r.mu.Unlock()
 
 	mic := make([]int16, 160)
@@ -259,6 +261,8 @@ func TestZeroPadLaggingChannel(t *testing.T) {
 	r := &Recorder{sampleRate: 16000}
 	r.mu.Lock()
 	r.recording = true
+	r.sysReady = true
+	r.sysAnchor = 1.0
 	r.mu.Unlock()
 
 	mic := make([]int16, 320)

--- a/scrib/audio/wav.go
+++ b/scrib/audio/wav.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
@@ -50,6 +51,45 @@ func StereoToMono(samples []int16) []int16 {
 		mono[i] = int16((int32(samples[i*2]) + int32(samples[i*2+1])) / 2)
 	}
 	return mono
+}
+
+func HighPass(samples []int16, sampleRate int, cutoffHz float64) []int16 {
+	if len(samples) == 0 {
+		return samples
+	}
+	omega := 2.0 * math.Pi * cutoffHz / float64(sampleRate)
+	alpha := math.Sin(omega) / (2.0 * 0.7071)
+
+	b0 := (1.0 + math.Cos(omega)) / 2.0
+	b1 := -(1.0 + math.Cos(omega))
+	b2 := (1.0 + math.Cos(omega)) / 2.0
+	a0 := 1.0 + alpha
+	a1 := -2.0 * math.Cos(omega)
+	a2 := 1.0 - alpha
+
+	b0 /= a0
+	b1 /= a0
+	b2 /= a0
+	a1 /= a0
+	a2 /= a0
+
+	out := make([]int16, len(samples))
+	var x1, x2, y1, y2 float64
+	for i, s := range samples {
+		x0 := float64(s)
+		y0 := b0*x0 + b1*x1 + b2*x2 - a1*y1 - a2*y2
+		if y0 > 32767 {
+			y0 = 32767
+		} else if y0 < -32768 {
+			y0 = -32768
+		}
+		out[i] = int16(y0)
+		x2 = x1
+		x1 = x0
+		y2 = y1
+		y1 = y0
+	}
+	return out
 }
 
 // WriteWAVTemp writes samples to a temporary WAV file and returns the path.

--- a/scrib/audio/wav_test.go
+++ b/scrib/audio/wav_test.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"math"
 	"os"
 	"testing"
 )
@@ -57,5 +58,115 @@ func TestStereoToMonoThenWriteWAV(t *testing.T) {
 	expectedSize := 44 + len(mono)*2
 	if info.Size() != int64(expectedSize) {
 		t.Errorf("mono WAV size = %d, want %d", info.Size(), expectedSize)
+	}
+}
+
+func TestHighPassEmpty(t *testing.T) {
+	out := HighPass(nil, 16000, 80)
+	if len(out) != 0 {
+		t.Errorf("expected empty, got %d", len(out))
+	}
+}
+
+func TestHighPassRemovesLowFrequency(t *testing.T) {
+	sr := 16000
+	dur := 2.0
+	n := int(dur * float64(sr))
+	samples := make([]int16, n)
+	for i := range samples {
+		samples[i] = int16(10000 * math.Sin(2*math.Pi*30*float64(i)/float64(sr)))
+	}
+
+	out := HighPass(samples, sr, 80)
+
+	var sumSq float64
+	for _, s := range out[sr/2:] {
+		sumSq += float64(s) * float64(s)
+	}
+	rmsOut := math.Sqrt(sumSq / float64(len(out[sr/2:])))
+
+	var sumSqIn float64
+	for _, s := range samples[sr/2:] {
+		sumSqIn += float64(s) * float64(s)
+	}
+	rmsIn := math.Sqrt(sumSqIn / float64(len(samples[sr/2:])))
+
+	attenuation := rmsOut / rmsIn
+	if attenuation > 0.15 {
+		t.Errorf("30Hz tone should be attenuated >85%%, got %.1f%% remaining", attenuation*100)
+	}
+}
+
+func TestHighPassPreservesSpeech(t *testing.T) {
+	sr := 16000
+	dur := 1.0
+	n := int(dur * float64(sr))
+	samples := make([]int16, n)
+	for i := range samples {
+		samples[i] = int16(10000 * math.Sin(2*math.Pi*500*float64(i)/float64(sr)))
+	}
+
+	out := HighPass(samples, sr, 80)
+
+	var sumSqOut float64
+	for _, s := range out[sr/4:] {
+		sumSqOut += float64(s) * float64(s)
+	}
+	rmsOut := math.Sqrt(sumSqOut / float64(len(out[sr/4:])))
+
+	var sumSqIn float64
+	for _, s := range samples[sr/4:] {
+		sumSqIn += float64(s) * float64(s)
+	}
+	rmsIn := math.Sqrt(sumSqIn / float64(len(samples[sr/4:])))
+
+	ratio := rmsOut / rmsIn
+	if ratio < 0.95 {
+		t.Errorf("500Hz tone should pass through with >95%% energy, got %.1f%%", ratio*100)
+	}
+}
+
+func TestHighPassRemovesDCOffset(t *testing.T) {
+	sr := 16000
+	n := sr
+	samples := make([]int16, n)
+	for i := range samples {
+		samples[i] = 5000
+	}
+
+	out := HighPass(samples, sr, 80)
+
+	var sum float64
+	for _, s := range out[sr/2:] {
+		sum += float64(s)
+	}
+	avg := sum / float64(len(out[sr/2:]))
+	if math.Abs(avg) > 50 {
+		t.Errorf("DC offset should be removed, got average %.1f", avg)
+	}
+}
+
+func TestHighPassOutputLength(t *testing.T) {
+	samples := make([]int16, 1000)
+	out := HighPass(samples, 16000, 80)
+	if len(out) != len(samples) {
+		t.Errorf("output length %d != input length %d", len(out), len(samples))
+	}
+}
+
+func TestHighPassNoClipping(t *testing.T) {
+	sr := 16000
+	n := sr
+	samples := make([]int16, n)
+	for i := range samples {
+		samples[i] = 32000
+	}
+
+	out := HighPass(samples, sr, 80)
+	for i, s := range out {
+		if s > 32767 || s < -32768 {
+			t.Errorf("sample %d clipped: %d", i, s)
+			break
+		}
 	}
 }

--- a/scrib/main.go
+++ b/scrib/main.go
@@ -175,17 +175,17 @@ func runUpload(cfg *config.Config, wavPath, template string) error {
 		return fmt.Errorf("read wav: %w", err)
 	}
 
-	uploadPath := abs
 	if channels == 2 {
 		fmt.Fprintf(os.Stderr, "Stereo WAV detected, downmixing to mono...\n")
 		samples = audio.StereoToMono(samples)
-		monoPath, err := audio.WriteWAVTemp(samples, cfg.SampleRate, 1)
-		if err != nil {
-			return fmt.Errorf("write mono wav: %w", err)
-		}
-		defer os.Remove(monoPath)
-		uploadPath = monoPath
 	}
+	samples = audio.HighPass(samples, cfg.SampleRate, 80)
+	monoPath, err := audio.WriteWAVTemp(samples, cfg.SampleRate, 1)
+	if err != nil {
+		return fmt.Errorf("write processed wav: %w", err)
+	}
+	defer os.Remove(monoPath)
+	uploadPath := monoPath
 
 	dur := time.Duration(len(samples)/cfg.SampleRate) * time.Second
 

--- a/scrib/ml/pyproject.toml
+++ b/scrib/ml/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "senko>=0.1.0",
     "soundfile>=0.13.0",
     "numpy>=2.0.0",
+    "noisereduce>=3.0.0",
     "python-multipart>=0.0.20",
 ]
 

--- a/scrib/ml/src/scrib_ml/diarize.py
+++ b/scrib/ml/src/scrib_ml/diarize.py
@@ -140,12 +140,20 @@ def diarize_array(
     speaker_set: set[str] = set()
     segments: list[DiarSegment] = []
 
+    overall_rms = float(np.sqrt(np.mean(data**2))) if len(data) > 0 else 0.0
+
     for seg in segments_raw:
         speaker = seg.get("speaker", "UNKNOWN")
         start = seg.get("start", 0.0)
         end = seg.get("end", 0.0)
         if (end - start) < min_duration:
             continue
+        start_sample = int(start * sr)
+        end_sample = min(int(end * sr), len(data))
+        if start_sample < end_sample and overall_rms > 0:
+            seg_rms = float(np.sqrt(np.mean(data[start_sample:end_sample] ** 2)))
+            if seg_rms < threshold * overall_rms:
+                continue
         segments.append(DiarSegment(
             speaker=speaker,
             start=round(start, 3),

--- a/scrib/ml/src/scrib_ml/pipeline.py
+++ b/scrib/ml/src/scrib_ml/pipeline.py
@@ -7,6 +7,7 @@ call that scrib-server can invoke.
 import logging
 from dataclasses import asdict, dataclass, field
 
+import noisereduce as nr
 import numpy as np
 import soundfile as sf
 
@@ -26,8 +27,70 @@ class PipelineResult:
     speaker_embeddings: dict[str, list[float]] = field(default_factory=dict)
 
 
+_TARGET_DBFS = -20.0
+_MAX_GAIN = 20.0
+_MIN_GAIN = 0.1
+_SILENCE_FLOOR_RMS = 1e-6
+_TRIM_THRESHOLD = 0.005
+_TRIM_MIN_SILENCE_SECS = 1.0
+
+
+def _trim_silence(data: np.ndarray, sr: int) -> tuple[np.ndarray, float]:
+    """Trim leading and trailing silence. Returns trimmed data and offset in seconds.
+
+    Only trims silence regions longer than _TRIM_MIN_SILENCE_SECS.
+    Internal silence is preserved for timestamp alignment.
+    """
+    frame_len = int(0.02 * sr)
+    energy = np.array([
+        np.sqrt(np.mean(data[i:i + frame_len] ** 2))
+        for i in range(0, len(data) - frame_len, frame_len)
+    ])
+
+    above = np.where(energy > _TRIM_THRESHOLD)[0]
+    if len(above) == 0:
+        return data, 0.0
+
+    first_voice = above[0] * frame_len
+    last_voice = (above[-1] + 1) * frame_len
+
+    min_samples = int(_TRIM_MIN_SILENCE_SECS * sr)
+    start = first_voice if first_voice > min_samples else 0
+    end = last_voice if (len(data) - last_voice) > min_samples else len(data)
+
+    offset = start / sr
+    return data[start:end], offset
+
+
+def _rms_normalize(data: np.ndarray, target_dbfs: float = _TARGET_DBFS) -> np.ndarray:
+    """Normalize audio RMS to target dBFS. Gain is capped to avoid amplifying noise."""
+    rms = float(np.sqrt(np.mean(data**2)))
+    if rms < _SILENCE_FLOOR_RMS:
+        return data
+    target_rms = 10.0 ** (target_dbfs / 20.0)
+    gain = target_rms / rms
+    gain = max(_MIN_GAIN, min(_MAX_GAIN, gain))
+    normalized = data * gain
+    peak = float(np.max(np.abs(normalized)))
+    if peak > 1.0:
+        normalized = normalized / peak
+    return normalized
+
+
+def _reduce_noise(data: np.ndarray, sr: int) -> np.ndarray:
+    """Apply stationary noise reduction (fan, HVAC, hum). Conservative to preserve speech."""
+    return nr.reduce_noise(
+        y=data,
+        sr=sr,
+        stationary=True,
+        prop_decrease=0.6,
+        n_fft=512,
+        freq_mask_smooth_hz=200,
+    )
+
+
 def _load_and_normalise(audio_path: str) -> tuple[np.ndarray, int]:
-    """Read audio → float32 mono 16kHz. Single normalisation point for the pipeline."""
+    """Read audio → float32 mono 16kHz, trimmed, noise-reduced, RMS-normalized."""
     data, sr = sf.read(audio_path, dtype="float32")
     if data.ndim > 1 and data.shape[1] > 1:
         data = np.mean(data, axis=1)
@@ -37,6 +100,16 @@ def _load_and_normalise(audio_path: str) -> tuple[np.ndarray, int]:
         sr = 16000
     if data.ndim != 1:
         data = data.reshape(-1)
+    original_dur = len(data) / sr
+    data, offset = _trim_silence(data, sr)
+    trimmed_dur = len(data) / sr
+    if offset > 0 or trimmed_dur < original_dur:
+        log.info(
+            "pipeline: trimmed %.1fs silence (offset=%.1fs, %.1fs → %.1fs)",
+            original_dur - trimmed_dur, offset, original_dur, trimmed_dur,
+        )
+    data = _reduce_noise(data, sr)
+    data = _rms_normalize(data)
     return data, sr
 
 

--- a/scrib/ml/tests/test_diarize_threshold.py
+++ b/scrib/ml/tests/test_diarize_threshold.py
@@ -1,0 +1,97 @@
+"""Tests for diarize_array threshold filtering."""
+
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+from scrib_ml.diarize import diarize_array, DiarSegment
+
+
+def _make_audio_with_loud_and_quiet(sr=16000):
+    """Create 10s audio: loud speech 0-5s, near-silence 5-10s."""
+    loud = 0.1 * np.random.default_rng(42).normal(0, 1, sr * 5).astype(np.float32)
+    quiet = 0.001 * np.random.default_rng(42).normal(0, 1, sr * 5).astype(np.float32)
+    return np.concatenate([loud, quiet])
+
+
+def _mock_diarizer_result():
+    """Fake Senko output with two segments: one loud, one quiet."""
+    return {
+        "merged_segments": [
+            {"speaker": "SPEAKER_0", "start": 0.0, "end": 5.0},
+            {"speaker": "SPEAKER_1", "start": 5.0, "end": 10.0},
+        ],
+    }
+
+
+class TestThresholdFilter:
+    @patch("scrib_ml.diarize.load_model")
+    def test_threshold_filters_quiet_segments(self, mock_load):
+        mock_diarizer = MagicMock()
+        mock_diarizer.diarize.return_value = _mock_diarizer_result()
+        mock_load.return_value = mock_diarizer
+
+        data = _make_audio_with_loud_and_quiet()
+        result = diarize_array(data, 16000, threshold=0.5)
+
+        speakers = [s.speaker for s in result.segments]
+        assert "SPEAKER_0" in speakers
+        assert "SPEAKER_1" not in speakers
+
+    @patch("scrib_ml.diarize.load_model")
+    def test_zero_threshold_keeps_all(self, mock_load):
+        mock_diarizer = MagicMock()
+        mock_diarizer.diarize.return_value = _mock_diarizer_result()
+        mock_load.return_value = mock_diarizer
+
+        data = _make_audio_with_loud_and_quiet()
+        result = diarize_array(data, 16000, threshold=0.0)
+
+        speakers = [s.speaker for s in result.segments]
+        assert "SPEAKER_0" in speakers
+        assert "SPEAKER_1" in speakers
+
+    @patch("scrib_ml.diarize.load_model")
+    def test_high_threshold_filters_more(self, mock_load):
+        mock_diarizer = MagicMock()
+        mock_diarizer.diarize.return_value = _mock_diarizer_result()
+        mock_load.return_value = mock_diarizer
+
+        data = _make_audio_with_loud_and_quiet()
+        result_low = diarize_array(data, 16000, threshold=0.1)
+        result_high = diarize_array(data, 16000, threshold=0.9)
+
+        assert len(result_high.segments) <= len(result_low.segments)
+
+    @patch("scrib_ml.diarize.load_model")
+    def test_threshold_with_uniform_audio_keeps_all(self, mock_load):
+        """When all segments have similar energy, none get filtered."""
+        mock_diarizer = MagicMock()
+        mock_diarizer.diarize.return_value = {
+            "merged_segments": [
+                {"speaker": "SPEAKER_0", "start": 0.0, "end": 3.0},
+                {"speaker": "SPEAKER_1", "start": 3.0, "end": 6.0},
+            ],
+        }
+        mock_load.return_value = mock_diarizer
+
+        rng = np.random.default_rng(42)
+        data = 0.1 * rng.normal(0, 1, 16000 * 6).astype(np.float32)
+        result = diarize_array(data, 16000, threshold=0.5)
+
+        assert len(result.segments) == 2
+
+    @patch("scrib_ml.diarize.load_model")
+    def test_threshold_does_not_affect_timestamps(self, mock_load):
+        mock_diarizer = MagicMock()
+        mock_diarizer.diarize.return_value = _mock_diarizer_result()
+        mock_load.return_value = mock_diarizer
+
+        data = _make_audio_with_loud_and_quiet()
+        result = diarize_array(data, 16000, threshold=0.5)
+
+        for seg in result.segments:
+            if seg.speaker == "SPEAKER_0":
+                assert seg.start == 0.0
+                assert seg.end == 5.0

--- a/scrib/ml/tests/test_normalize.py
+++ b/scrib/ml/tests/test_normalize.py
@@ -1,0 +1,282 @@
+"""Integration tests for pipeline audio normalization."""
+
+import math
+import tempfile
+import wave
+import struct
+
+import numpy as np
+import pytest
+
+from scrib_ml.pipeline import _rms_normalize, _reduce_noise, _trim_silence, _load_and_normalise
+
+
+def _rms_dbfs(data: np.ndarray) -> float:
+    rms = float(np.sqrt(np.mean(data**2)))
+    if rms < 1e-10:
+        return -100.0
+    return 20.0 * math.log10(rms)
+
+
+def _write_wav(path: str, samples: np.ndarray, sr: int = 16000, channels: int = 1):
+    int_samples = np.clip(samples * 32767, -32768, 32767).astype(np.int16)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(channels)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(int_samples.tobytes())
+
+
+class TestRmsNormalize:
+    def test_quiet_audio_boosted(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.003, 16000).astype(np.float32)
+        original_rms = _rms_dbfs(data)
+        assert original_rms < -45
+
+        result = _rms_normalize(data)
+        result_rms = _rms_dbfs(result)
+        assert result_rms > original_rms + 20
+
+    def test_moderate_quiet_audio_hits_target(self):
+        """Audio at -30 dBFS (typical scrib recording) should reach -20 dBFS."""
+        rng = np.random.default_rng(42)
+        target_rms = 10.0 ** (-30.0 / 20.0)
+        data = rng.normal(0, 1.0, 16000).astype(np.float32)
+        data = data * (target_rms / float(np.sqrt(np.mean(data**2))))
+
+        result = _rms_normalize(data)
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+    def test_loud_audio_attenuated(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.5, 16000).astype(np.float32)
+        original_rms = _rms_dbfs(data)
+        assert original_rms > -10
+
+        result = _rms_normalize(data)
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+    def test_already_normalized_unchanged(self):
+        target_rms = 10.0 ** (-20.0 / 20.0)
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 1.0, 16000).astype(np.float32)
+        current_rms = float(np.sqrt(np.mean(data**2)))
+        data = data * (target_rms / current_rms)
+
+        result = _rms_normalize(data)
+        result_rms = _rms_dbfs(result)
+        assert -21.0 < result_rms < -19.0
+
+    def test_silence_not_amplified(self):
+        data = np.zeros(16000, dtype=np.float32)
+        result = _rms_normalize(data)
+        assert np.all(result == 0)
+
+    def test_near_silence_gain_capped(self):
+        data = np.full(16000, 1e-5, dtype=np.float32)
+        result = _rms_normalize(data)
+        gain = float(np.max(np.abs(result))) / float(np.max(np.abs(data)))
+        assert gain <= 20.0
+
+    def test_peak_never_exceeds_one(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.001, 16000).astype(np.float32)
+        data[100] = 0.8
+        result = _rms_normalize(data)
+        assert float(np.max(np.abs(result))) <= 1.0
+
+    def test_does_not_invert_phase(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.01, 16000).astype(np.float32)
+        result = _rms_normalize(data)
+        correlation = float(np.corrcoef(data, result)[0, 1])
+        assert correlation > 0.99
+
+
+class TestLoadAndNormalise:
+    def test_mono_16k_wav(self):
+        """A -30 dBFS recording should be normalized to ~-20 dBFS."""
+        rng = np.random.default_rng(42)
+        target_rms = 10.0 ** (-30.0 / 20.0)
+        data = rng.normal(0, 1.0, 16000).astype(np.float32)
+        data = data * (target_rms / float(np.sqrt(np.mean(data**2))))
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            _write_wav(f.name, data)
+            result, sr = _load_and_normalise(f.name)
+        assert sr == 16000
+        assert result.ndim == 1
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+    def test_stereo_downmixed_and_normalized(self):
+        rng = np.random.default_rng(42)
+        target_rms = 10.0 ** (-30.0 / 20.0)
+        left = rng.normal(0, 1.0, 16000).astype(np.float32)
+        left = left * (target_rms / float(np.sqrt(np.mean(left**2))))
+        right = rng.normal(0, 1.0, 16000).astype(np.float32)
+        right = right * (target_rms / float(np.sqrt(np.mean(right**2))))
+        stereo = np.column_stack([left, right]).flatten()
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            _write_wav(f.name, stereo, channels=2)
+            result, sr = _load_and_normalise(f.name)
+        assert sr == 16000
+        assert result.ndim == 1
+        assert len(result) == 16000
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+    def test_48k_resampled(self):
+        rng = np.random.default_rng(42)
+        target_rms = 10.0 ** (-30.0 / 20.0)
+        data = rng.normal(0, 1.0, 48000).astype(np.float32)
+        data = data * (target_rms / float(np.sqrt(np.mean(data**2))))
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            _write_wav(f.name, data, sr=48000)
+            result, sr = _load_and_normalise(f.name)
+        assert sr == 16000
+        assert 15900 < len(result) < 16100
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+    def test_real_world_level_minus_30(self):
+        """Simulates a typical scrib recording at -30 dBFS RMS."""
+        rng = np.random.default_rng(42)
+        target_rms = 10.0 ** (-30.0 / 20.0)
+        data = rng.normal(0, 1.0, 16000 * 10).astype(np.float32)
+        current_rms = float(np.sqrt(np.mean(data**2)))
+        data = data * (target_rms / current_rms)
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            _write_wav(f.name, data)
+            result, sr = _load_and_normalise(f.name)
+        result_rms = _rms_dbfs(result)
+        assert -22.0 < result_rms < -18.0
+
+
+class TestReduceNoise:
+    def test_reduces_stationary_noise(self):
+        """Stationary hum (like HVAC) should be attenuated."""
+        rng = np.random.default_rng(42)
+        sr = 16000
+        t = np.linspace(0, 2, sr * 2, endpoint=False)
+        hum = 0.02 * np.sin(2 * np.pi * 120 * t).astype(np.float32)
+        noise = 0.01 * rng.normal(0, 1, sr * 2).astype(np.float32)
+        signal = hum + noise
+
+        result = _reduce_noise(signal, sr)
+        original_rms = float(np.sqrt(np.mean(signal**2)))
+        result_rms = float(np.sqrt(np.mean(result**2)))
+        assert result_rms < original_rms * 0.8
+
+    def test_preserves_speech_frequencies(self):
+        """Broadband non-stationary signal (speech-like) should be mostly preserved."""
+        rng = np.random.default_rng(42)
+        sr = 16000
+        t = np.linspace(0, 2, sr * 2, endpoint=False)
+        envelope = (0.5 + 0.5 * np.sin(2 * np.pi * 3 * t)).astype(np.float32)
+        f0 = 200 + 600 * t / 2
+        speech = 0.1 * envelope * np.sin(2 * np.pi * f0 * t).astype(np.float32)
+        harmonics = 0.05 * envelope * np.sin(2 * np.pi * f0 * 2 * t).astype(np.float32)
+        speech = speech + harmonics
+        noise = 0.005 * rng.normal(0, 1, sr * 2).astype(np.float32)
+        signal = speech + noise
+
+        result = _reduce_noise(signal, sr)
+        speech_rms = float(np.sqrt(np.mean(speech**2)))
+        result_rms = float(np.sqrt(np.mean(result**2)))
+        assert result_rms > speech_rms * 0.3
+
+    def test_silence_stays_silent(self):
+        """Near-silence input should remain near-silent, not amplify artifacts."""
+        data = np.zeros(16000, dtype=np.float32)
+        data[100] = 0.001
+        result = _reduce_noise(data, 16000)
+        assert float(np.max(np.abs(result))) < 0.01
+
+    def test_output_shape_unchanged(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.01, 32000).astype(np.float32)
+        result = _reduce_noise(data, 16000)
+        assert result.shape == data.shape
+
+    def test_does_not_clip(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(0, 0.1, 16000).astype(np.float32)
+        result = _reduce_noise(data, 16000)
+        assert float(np.max(np.abs(result))) <= 1.0
+
+
+class TestTrimSilence:
+    def test_trims_leading_silence(self):
+        sr = 16000
+        silence = np.zeros(sr * 3, dtype=np.float32)
+        speech = 0.1 * np.ones(sr * 2, dtype=np.float32)
+        data = np.concatenate([silence, speech])
+
+        result, offset = _trim_silence(data, sr)
+        assert offset > 1.0
+        assert len(result) < len(data)
+        assert len(result) >= sr * 2
+
+    def test_trims_trailing_silence(self):
+        sr = 16000
+        speech = 0.1 * np.ones(sr * 2, dtype=np.float32)
+        silence = np.zeros(sr * 3, dtype=np.float32)
+        data = np.concatenate([speech, silence])
+
+        result, offset = _trim_silence(data, sr)
+        assert offset == 0.0
+        assert len(result) < len(data)
+        assert len(result) >= sr * 2
+
+    def test_trims_both_ends(self):
+        sr = 16000
+        silence = np.zeros(sr * 2, dtype=np.float32)
+        speech = 0.1 * np.ones(sr * 3, dtype=np.float32)
+        data = np.concatenate([silence, speech, silence])
+
+        result, offset = _trim_silence(data, sr)
+        assert offset > 0.5
+        assert len(result) < len(data)
+
+    def test_preserves_internal_silence(self):
+        sr = 16000
+        speech1 = 0.1 * np.ones(sr, dtype=np.float32)
+        gap = np.zeros(sr * 2, dtype=np.float32)
+        speech2 = 0.1 * np.ones(sr, dtype=np.float32)
+        data = np.concatenate([speech1, gap, speech2])
+
+        result, offset = _trim_silence(data, sr)
+        assert offset == 0.0
+        assert len(result) == len(data)
+
+    def test_short_silence_not_trimmed(self):
+        """Silence under 1s at edges should not be trimmed."""
+        sr = 16000
+        short_silence = np.zeros(int(sr * 0.5), dtype=np.float32)
+        speech = 0.1 * np.ones(sr * 2, dtype=np.float32)
+        data = np.concatenate([short_silence, speech])
+
+        result, offset = _trim_silence(data, sr)
+        assert offset == 0.0
+        assert len(result) == len(data)
+
+    def test_all_silence_returns_unchanged(self):
+        sr = 16000
+        data = np.zeros(sr * 5, dtype=np.float32)
+
+        result, offset = _trim_silence(data, sr)
+        assert offset == 0.0
+        assert len(result) == len(data)
+
+    def test_no_silence_unchanged(self):
+        sr = 16000
+        rng = np.random.default_rng(42)
+        data = 0.1 * rng.normal(0, 1, sr * 3).astype(np.float32)
+
+        result, offset = _trim_silence(data, sr)
+        assert offset == 0.0
+        assert len(result) == len(data)

--- a/scrib/tui/tui.go
+++ b/scrib/tui/tui.go
@@ -391,6 +391,7 @@ func (m model) runSave() tea.Cmd {
 		// Pre-compute mono WAV to disk so retry doesn't re-downmix and doesn't
 		// hold the full stereo buffer in RAM across the upload.
 		mono := audio.StereoToMono(samples)
+		mono = audio.HighPass(mono, m.opts.SampleRate, 80)
 		monoPath, err := audio.WriteWAVTemp(mono, m.opts.SampleRate, 1)
 		if err != nil {
 			return savedMsg{err: fmt.Errorf("mono wav: %w", err)}


### PR DESCRIPTION
## Summary

Audio quality improvements for scrib client and ML pipeline, based on analysis of real recordings from Garage S3 (all at -29 to -31 dBFS, ~45% silence).

## Client (Go)

- 80Hz 2nd-order biquad high-pass filter — removes DC offset, room rumble, HVAC hum
- Applied in both TUI save flow and CLI upload path

## ML Pipeline (Python)

- **RMS normalization** to -20 dBFS (gain-capped at 20x to avoid amplifying noise)
- **Spectral noise reduction** via noisereduce (stationary mode, conservative prop_decrease=0.6)
- **Silence trimming** — leading/trailing silence >1s removed before inference (saves compute)
- **Threshold parameter fixed** — now filters diarization segments below threshold × overall RMS

## Tests

- 6 high-pass filter tests (Go)
- 12 RMS normalization tests (Python)
- 5 noise reduction tests (Python)
- 7 silence trimming tests (Python)
- 5 threshold filtering tests (Python)
- Fixed pre-existing recorder test failures (backlog flush bypass)

## Also fixed

- Garage S3 was down (read-only PV from Ceph RBD) — fixed by deleting pod to force fresh volume attach