### PR TITLE
feat(pii-adapter): Presidio-backed PII scrubbing HTTP adapter

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -66,6 +66,7 @@ jobs:
               - 'kobo/**'
               - 'line/**'
               - 'nodepool-autoscaler/**'
+              - 'pii-adapter/**'
               - 'tools/**'
               - 'yield/**'
             scrib:

--- a/pii-adapter/BUILD.bazel
+++ b/pii-adapter/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+
+go_library(
+    name = "lib",
+    srcs = glob(["*.go"]),
+    importpath = "github.com/solanyn/mono/pii-adapter",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "pii-adapter",
+    embed = [":lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_cross_binary(
+    name = "pii-adapter_linux_amd64",
+    platform = "@rules_go//go/toolchain:linux_amd64",
+    target = ":pii-adapter",
+)
+
+go_cross_binary(
+    name = "pii-adapter_linux_arm64",
+    platform = "@rules_go//go/toolchain:linux_arm64",
+    target = ":pii-adapter",
+)
+
+tar(
+    name = "layer",
+    srcs = [":pii-adapter_linux_amd64"],
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_static",
+    entrypoint = ["/pii-adapter_linux_amd64"],
+    tars = [":layer"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["pii-adapter:latest"],
+)
+
+oci_push(
+    name = "push",
+    image = ":image",
+    repository = "ghcr.io/solanyn/pii-adapter",
+)

--- a/pii-adapter/config.go
+++ b/pii-adapter/config.go
@@ -1,0 +1,35 @@
+package main
+
+import "os"
+
+// Config holds runtime configuration sourced from environment variables.
+type Config struct {
+	// PresidioURL is the base URL of the Presidio Analyzer REST API.
+	PresidioURL string
+	// ScoreThreshold is the minimum confidence score for a detection to be
+	// considered. Sent to Presidio as a string per its API contract.
+	ScoreThreshold string
+	// ListenAddr is the address the HTTP adapter binds to.
+	ListenAddr string
+	// Language is the ISO language code passed to Presidio.
+	Language string
+}
+
+// loadConfig reads configuration from the environment, applying defaults.
+func loadConfig() Config {
+	return Config{
+		PresidioURL:    getenv("PRESIDIO_ANALYZER_URL", "http://localhost:3000"),
+		ScoreThreshold: getenv("SCORE_THRESHOLD", "0.5"),
+		ListenAddr:     getenv("LISTEN_ADDR", ":8000"),
+		Language:       getenv("LANGUAGE", "en"),
+	}
+}
+
+// getenv returns the value of the environment variable named by key, or def if
+// it is unset or empty.
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/pii-adapter/go.mod
+++ b/pii-adapter/go.mod
@@ -1,0 +1,3 @@
+module github.com/solanyn/mono/pii-adapter
+
+go 1.23

--- a/pii-adapter/handlers.go
+++ b/pii-adapter/handlers.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// webhookRequest is the agentgateway Guardrail Webhook payload. The body is
+// kept as a generic map so unknown fields round-trip unmodified.
+type webhookRequest struct {
+	Body map[string]interface{} `json:"body"`
+}
+
+// handleRequest scrubs PII from the messages of an inbound request body.
+func (s *server) handleRequest(w http.ResponseWriter, r *http.Request) {
+	req, ok := decodeWebhook(w, r)
+	if !ok {
+		return
+	}
+
+	messages, ok := req.Body["messages"].([]interface{})
+	if !ok {
+		writePass(w)
+		return
+	}
+
+	changed := false
+	for _, m := range messages {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		content, exists := msg["content"]
+		if !exists {
+			continue
+		}
+		scrubbed, c, err := scrubContent(r.Context(), s.client, content)
+		if err != nil {
+			log.Printf("warning: scrub failed on request, failing open: %v", err)
+			writePass(w)
+			return
+		}
+		if c {
+			msg["content"] = scrubbed
+			changed = true
+		}
+	}
+
+	if changed {
+		writeMask(w, req.Body)
+		return
+	}
+	writePass(w)
+}
+
+// handleResponse scrubs PII from the choices of an outbound response body.
+func (s *server) handleResponse(w http.ResponseWriter, r *http.Request) {
+	req, ok := decodeWebhook(w, r)
+	if !ok {
+		return
+	}
+
+	choices, ok := req.Body["choices"].([]interface{})
+	if !ok {
+		writePass(w)
+		return
+	}
+
+	changed := false
+	for _, ch := range choices {
+		choice, ok := ch.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		msg, ok := choice["message"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		content, exists := msg["content"]
+		if !exists {
+			continue
+		}
+		scrubbed, c, err := scrubContent(r.Context(), s.client, content)
+		if err != nil {
+			log.Printf("warning: scrub failed on response, failing open: %v", err)
+			writePass(w)
+			return
+		}
+		if c {
+			msg["content"] = scrubbed
+			changed = true
+		}
+	}
+
+	if changed {
+		writeMask(w, req.Body)
+		return
+	}
+	writePass(w)
+}
+
+// handleHealth reports adapter health based on Presidio's /health endpoint.
+func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	analyzerUp := s.client.health(r.Context())
+	resp := map[string]interface{}{"analyzer": analyzerUp}
+	if analyzerUp {
+		resp["status"] = "ok"
+	} else {
+		resp["status"] = "degraded"
+	}
+	writeJSON(w, resp)
+}
+
+// decodeWebhook decodes the request body. On any decode error or missing body
+// it fails open by writing a pass response and returns ok=false.
+func decodeWebhook(w http.ResponseWriter, r *http.Request) (webhookRequest, bool) {
+	var req webhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Printf("warning: failed to decode webhook body, failing open: %v", err)
+		writePass(w)
+		return req, false
+	}
+	if req.Body == nil {
+		writePass(w)
+		return req, false
+	}
+	return req, true
+}
+
+// writePass emits the fail-open / no-change response.
+func writePass(w http.ResponseWriter) {
+	writeJSON(w, map[string]interface{}{"action": "pass"})
+}
+
+// writeMask emits a mask response carrying the modified body.
+func writeMask(w http.ResponseWriter, body map[string]interface{}) {
+	writeJSON(w, map[string]interface{}{"action": "mask", "body": body})
+}
+
+// writeJSON writes v as a JSON response. Encoding failures are logged but not
+// surfaced, keeping the adapter fail-open.
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("warning: failed to encode response: %v", err)
+	}
+}

--- a/pii-adapter/main.go
+++ b/pii-adapter/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+// server wires HTTP handlers to a Presidio client.
+type server struct {
+	client *presidioClient
+}
+
+func main() {
+	cfg := loadConfig()
+	srv := &server{client: newPresidioClient(cfg)}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /request", srv.handleRequest)
+	mux.HandleFunc("POST /response", srv.handleResponse)
+	mux.HandleFunc("GET /health", srv.handleHealth)
+
+	httpServer := &http.Server{
+		Addr:    cfg.ListenAddr,
+		Handler: mux,
+	}
+
+	log.Printf("pii-adapter listening on %s (presidio: %s)", cfg.ListenAddr, cfg.PresidioURL)
+	if err := httpServer.ListenAndServe(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/pii-adapter/placeholders.go
+++ b/pii-adapter/placeholders.go
@@ -1,0 +1,29 @@
+package main
+
+// placeholders maps Presidio entity types to the redaction token used to
+// replace detected spans.
+var placeholders = map[string]string{
+	"PERSON":        "[PERSON]",
+	"LOCATION":      "[LOCATION]",
+	"GPE":           "[LOCATION]",
+	"ORGANIZATION":  "[ORG]",
+	"PHONE_NUMBER":  "[PHONE]",
+	"EMAIL_ADDRESS": "[EMAIL]",
+	"CREDIT_CARD":   "[CREDIT_CARD]",
+	"IP_ADDRESS":    "[IP]",
+	"URL":           "[URL]",
+	"IBAN_CODE":     "[IBAN]",
+	"US_SSN":        "[SSN]",
+	"DATE_TIME":     "[DATE]",
+	"NRP":           "[GROUP]",
+}
+
+// placeholderFor returns the redaction token for the given Presidio entity
+// type. Unknown entity types are wrapped in brackets verbatim, e.g. an unknown
+// type "MEDICAL_LICENSE" becomes "[MEDICAL_LICENSE]".
+func placeholderFor(entityType string) string {
+	if p, ok := placeholders[entityType]; ok {
+		return p
+	}
+	return "[" + entityType + "]"
+}

--- a/pii-adapter/presidio.go
+++ b/pii-adapter/presidio.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// analyzeResult is a single PII detection returned by Presidio's /analyze
+// endpoint. Start and End are offsets into the analyzed text.
+type analyzeResult struct {
+	EntityType string  `json:"entity_type"`
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+}
+
+// presidioClient is a thin HTTP client for the Presidio Analyzer REST API.
+type presidioClient struct {
+	baseURL        string
+	language       string
+	scoreThreshold string
+	http           *http.Client
+}
+
+// newPresidioClient constructs a client from the given configuration. The
+// underlying HTTP client enforces a 5s timeout on every request.
+func newPresidioClient(cfg Config) *presidioClient {
+	return &presidioClient{
+		baseURL:        cfg.PresidioURL,
+		language:       cfg.Language,
+		scoreThreshold: cfg.ScoreThreshold,
+		http:           &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// analyze calls Presidio POST /analyze and returns the detected PII spans.
+func (c *presidioClient) analyze(ctx context.Context, text string) ([]analyzeResult, error) {
+	payload, err := json.Marshal(map[string]string{
+		"text":            text,
+		"language":        c.language,
+		"score_threshold": c.scoreThreshold,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/analyze", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("presidio /analyze returned status %d", resp.StatusCode)
+	}
+
+	var results []analyzeResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// health calls Presidio GET /health and reports whether the analyzer is up.
+func (c *presidioClient) health(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/pii-adapter/scrub.go
+++ b/pii-adapter/scrub.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"log"
+	"sort"
+)
+
+// scrubText analyzes text via Presidio and replaces every detected PII span
+// with its placeholder. Spans are replaced from end to start so the byte
+// offsets of not-yet-replaced spans stay valid. It returns the (possibly)
+// modified text and whether any replacement was made.
+func scrubText(ctx context.Context, client *presidioClient, text string) (string, bool, error) {
+	if text == "" {
+		return text, false, nil
+	}
+
+	results, err := client.analyze(ctx, text)
+	if err != nil {
+		return text, false, err
+	}
+	if len(results) == 0 {
+		return text, false, nil
+	}
+
+	// Replace from the highest start offset to the lowest so that each
+	// replacement leaves the offsets of the remaining (lower) spans valid.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Start > results[j].Start
+	})
+
+	scrubbed := text
+	changed := false
+	// prevStart tracks the start offset of the last span we replaced. Any
+	// span whose end extends into already-replaced territory overlaps it and
+	// is skipped to avoid corrupting offsets.
+	prevStart := len(text)
+	for _, r := range results {
+		if r.Start < 0 || r.End > len(text) || r.Start >= r.End {
+			log.Printf("warning: skipping invalid span [%d:%d] for %s (text length %d)", r.Start, r.End, r.EntityType, len(text))
+			continue
+		}
+		if r.End > prevStart {
+			log.Printf("warning: skipping overlapping span [%d:%d] for %s", r.Start, r.End, r.EntityType)
+			continue
+		}
+		scrubbed = scrubbed[:r.Start] + placeholderFor(r.EntityType) + scrubbed[r.End:]
+		prevStart = r.Start
+		changed = true
+	}
+	return scrubbed, changed, nil
+}
+
+// scrubContent scrubs a chat message "content" value, which may be either a
+// plain string or a multimodal array of parts. For arrays, only parts with
+// type "text" are scrubbed. It returns the modified content and whether any
+// change was made.
+func scrubContent(ctx context.Context, client *presidioClient, content interface{}) (interface{}, bool, error) {
+	switch v := content.(type) {
+	case string:
+		return scrubText(ctx, client, v)
+	case []interface{}:
+		changed := false
+		for _, part := range v {
+			m, ok := part.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if t, _ := m["type"].(string); t != "text" {
+				continue
+			}
+			txt, ok := m["text"].(string)
+			if !ok {
+				continue
+			}
+			scrubbed, c, err := scrubText(ctx, client, txt)
+			if err != nil {
+				return content, false, err
+			}
+			if c {
+				m["text"] = scrubbed
+				changed = true
+			}
+		}
+		return v, changed, nil
+	default:
+		return content, false, nil
+	}
+}


### PR DESCRIPTION
## Summary
Adds `pii-adapter/`, a thin stdlib-only Go HTTP adapter between agentgateway's Guardrail Webhook API and Microsoft Presidio Analyzer (runs as an in-cluster sidecar at `http://localhost:3000`).

Endpoints:
- `POST /request` — extracts text from each message's content (string or multimodal `type: "text"` parts), calls Presidio `/analyze`, replaces detected spans with placeholders. Returns `{"action":"mask","body":{...}}` if anything changed, else `{"action":"pass"}`.
- `POST /response` — same, scrubbing `choices[].message.content`.
- `GET /health` — proxies Presidio `/health`, returns `{"status":"ok","analyzer":true}` or degraded.

Key behaviors:
- Fail open — any error (Presidio down, parse failure) returns `{"action":"pass"}`.
- Spans replaced end-to-start so offsets stay valid; invalid/overlapping spans skipped with a logged warning.
- 5s HTTP client timeout to Presidio.
- Config via env: `PRESIDIO_ANALYZER_URL`, `SCORE_THRESHOLD`, `LISTEN_ADDR`, `LANGUAGE`.

Build: `BUILD.bazel` follows the cronprint pattern (go_library/go_binary/go_cross_binary linux_amd64+arm64/tar/oci_image on `@distroless_static`/oci_load/oci_push to `ghcr.io/solanyn/pii-adapter`). Zero external deps, so no MODULE.bazel change.

## Testing
- `bazel build //pii-adapter:pii-adapter` — passes.
- Temporary httptest-backed unit tests covering end-to-start replacement, unknown-entity fallback (`[ENTITY_TYPE]`), multimodal scrubbing, and fail-open on connection error — all passed; test file removed so the committed `glob(["*.go"])` matches the cronprint pattern.

## Notes
- No auth on the endpoints — intentional, runs in-cluster as a localhost sidecar peer.