### PR TITLE
feat(agentgateway-discovery): add on-demand /v1/models aggregator

### DIFF
--- a/agentgateway-discovery/BUILD.bazel
+++ b/agentgateway-discovery/BUILD.bazel
@@ -1,0 +1,60 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+go_library(
+    name = "lib",
+    srcs = glob(["*.go"]),
+    importpath = "github.com/solanyn/mono/agentgateway-discovery",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "agentgateway-discovery",
+    embed = [":lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "agentgateway-discovery_linux_amd64",
+    embed = [":lib"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "agentgateway-discovery_linux_arm64",
+    embed = [":lib"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "layer",
+    srcs = [":agentgateway-discovery_linux_amd64"],
+    strip_prefix = ".",
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_static",
+    entrypoint = ["/agentgateway-discovery_linux_amd64_/agentgateway-discovery_linux_amd64"],
+    labels = {"org.opencontainers.image.source": "https://github.com/solanyn/mono"},
+    tars = [":layer"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["agentgateway-discovery:latest"],
+)
+
+oci_push(
+    name = "push",
+    image = ":image",
+    repository = "ghcr.io/solanyn/agentgateway-discovery",
+)

--- a/agentgateway-discovery/README.md
+++ b/agentgateway-discovery/README.md
@@ -1,0 +1,40 @@
+# agentgateway-discovery
+
+On-demand `/v1/models` aggregator for AgentGateway. Queries each upstream LLM provider's `/v1/models` endpoint live and merges the results into a single OpenAI-compatible list, cached in memory for 30 s.
+
+```mermaid
+graph LR
+    ag["AgentGateway /v1/models"] --> disc["agentgateway-discovery :8080"]
+    disc -->|cache miss| mlx["mlx (internal)"]
+    disc -->|cache miss| minimax["MiniMax"]
+    disc -->|cache miss| deepseek["DeepSeek"]
+    disc -.->|30s TTL| cache[("in-memory cache")]
+```
+
+## Run
+
+```bash
+bazel run //agentgateway-discovery:load
+docker run --rm -p 8080:8080 \
+  -e MINIMAX_API_KEY=... \
+  -e DEEPSEEK_API_KEY=... \
+  agentgateway-discovery:latest
+```
+
+## Config
+
+| Env var           | Default | Purpose                                       |
+| ----------------- | ------- | --------------------------------------------- |
+| `PORT`            | `8080`  | Listen port                                   |
+| `MINIMAX_API_KEY` | (unset) | Bearer token for `api.minimaxi.chat`         |
+| `DEEPSEEK_API_KEY`| (unset) | Bearer token for `api.deepseek.com`          |
+
+The `mlx` provider targets `http://mac.internal:8080/v1/models` and never sends an Authorization header. Other providers send `Authorization: Bearer <env>` only when the env var is non-empty.
+
+## Endpoints
+
+| Method | Path        | Response                                                 |
+| ------ | ----------- | -------------------------------------------------------- |
+| `GET`  | `/v1/models`| OpenAI-compatible merged model list (cached 30 s)        |
+| `GET`  | `/healthz`  | `200 ok` (liveness + readiness probes)                   |
+| any    | other       | `404`                                                    |

--- a/agentgateway-discovery/README.md
+++ b/agentgateway-discovery/README.md
@@ -23,13 +23,42 @@ docker run --rm -p 8080:8080 \
 
 ## Config
 
-| Env var           | Default | Purpose                                       |
-| ----------------- | ------- | --------------------------------------------- |
-| `PORT`            | `8080`  | Listen port                                   |
-| `MINIMAX_API_KEY` | (unset) | Bearer token for `api.minimaxi.chat`         |
-| `DEEPSEEK_API_KEY`| (unset) | Bearer token for `api.deepseek.com`          |
+Providers and their API keys come from env vars. Recognized variables:
 
-The `mlx` provider targets `http://mac.internal:8080/v1/models` and never sends an Authorization header. Other providers send `Authorization: Bearer <env>` only when the env var is non-empty.
+```
+DISCOVERY_PROVIDER_<NAME>_URL=https://...          (required per provider)
+DISCOVERY_PROVIDER_<NAME>_API_KEY=<bearer-token>   (optional)
+```
+
+`<NAME>` is lowercased and used as the provider identifier (logs and `owned_by` default). If no `DISCOVERY_PROVIDER_*` env vars are set, three built-in defaults are used:
+
+| Provider  | URL                                          | Auth         |
+| --------- | -------------------------------------------- | ------------ |
+| `mlx`     | `http://mac.internal:8080/v1/models`         | none         |
+| `minimax` | `https://api.minimaxi.chat/v1/models`        | via env      |
+| `deepseek`| `https://api.deepseek.com/v1/models`         | via env      |
+
+Other env vars:
+
+| Env var | Default | Purpose     |
+| ------- | ------- | ----------- |
+| `PORT`  | `8080`  | Listen port |
+
+In Kubernetes, source each provider's API key from its own Secret via `valueFrom.secretKeyRef`:
+
+```yaml
+env:
+  - name: DISCOVERY_PROVIDER_MLX_URL
+    value: "http://mac.internal:8080/v1/models"
+  - name: DISCOVERY_PROVIDER_MINIMAX_URL
+    value: "https://api.minimaxi.chat/v1/models"
+  - name: DISCOVERY_PROVIDER_MINIMAX_API_KEY
+    valueFrom: { secretKeyRef: { name: minimax-auth, key: api-key } }
+  - name: DISCOVERY_PROVIDER_DEEPSEEK_URL
+    value: "https://api.deepseek.com/v1/models"
+  - name: DISCOVERY_PROVIDER_DEEPSEEK_API_KEY
+    valueFrom: { secretKeyRef: { name: deepseek-auth, key: api-key } }
+```
 
 ## Endpoints
 

--- a/agentgateway-discovery/go.mod
+++ b/agentgateway-discovery/go.mod
@@ -1,0 +1,3 @@
+module github.com/solanyn/mono/agentgateway-discovery
+
+go 1.26.3

--- a/agentgateway-discovery/main.go
+++ b/agentgateway-discovery/main.go
@@ -1,0 +1,304 @@
+// Package main implements agentgateway-discovery — an on-demand /v1/models
+// aggregator for AgentGateway. Instead of a cronjob refreshing a static
+// configmap, this service queries each upstream LLM provider's /v1/models
+// endpoint live when the discovery endpoint is called, merges the results
+// into a single OpenAI-compatible list, and caches the merged payload in
+// memory for a short TTL to avoid hammering upstreams.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	cacheTTL    = 30 * time.Second
+	upstreamTTL = 10 * time.Second
+	defaultOwn  = "agentgateway"
+)
+
+// Provider describes one upstream OpenAI-compatible /v1/models endpoint.
+// APIKeyEnv names an environment variable that — when set — supplies the
+// Bearer token sent to that provider. An empty APIKeyEnv disables auth.
+type Provider struct {
+	Name      string
+	URL       string
+	APIKeyEnv string
+}
+
+// providers is the static upstream set. Order is preserved in the merged
+// output so the response is stable for clients that key off position.
+var providers = []Provider{
+	{Name: "mlx", URL: "http://mac.internal:8080/v1/models", APIKeyEnv: ""},
+	{Name: "minimax", URL: "https://api.minimaxi.chat/v1/models", APIKeyEnv: "MINIMAX_API_KEY"},
+	{Name: "deepseek", URL: "https://api.deepseek.com/v1/models", APIKeyEnv: "DEEPSEEK_API_KEY"},
+}
+
+// Model is the OpenAI-compatible model object emitted in the response.
+// Tags match OpenAI's /v1/models schema; extra upstream fields are ignored.
+type Model struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	OwnedBy string `json:"owned_by"`
+	Created int64  `json:"created"`
+}
+
+// upstreamResponse is what we expect to decode from each provider's /v1/models.
+type upstreamResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+// outputResponse is the merged payload we serve.
+type outputResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+// entry is one TTL-cached payload. We store marshalled bytes rather than
+// the struct so we don't pay JSON encoding cost on the hot path.
+type entry struct {
+	bytes     []byte
+	expiresAt time.Time
+}
+
+// modelCache is a one-slot TTL cache for the merged /v1/models payload.
+// Key is intentionally constant — there is exactly one cache entry.
+type modelCache struct {
+	mu   sync.RWMutex
+	data *entry
+}
+
+func (c *modelCache) get(now time.Time) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.data == nil || !now.Before(c.data.expiresAt) {
+		return nil, false
+	}
+	// hand back a copy so callers can't mutate the cached buffer
+	out := make([]byte, len(c.data.bytes))
+	copy(out, c.data.bytes)
+	return out, true
+}
+
+func (c *modelCache) set(b []byte, expiresAt time.Time) {
+	stored := make([]byte, len(b))
+	copy(stored, b)
+	c.mu.Lock()
+	c.data = &entry{bytes: stored, expiresAt: expiresAt}
+	c.mu.Unlock()
+}
+
+// fetchProvider GETs /v1/models from one upstream and returns its models.
+// Auth: if the named env var is set, send Authorization: Bearer <value>.
+// Otherwise the request goes out without an Authorization header.
+func fetchProvider(ctx context.Context, p Provider) ([]Model, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: build request: %w", p.Name, err)
+	}
+	if p.APIKeyEnv != "" {
+		if key := os.Getenv(p.APIKeyEnv); key != "" {
+			req.Header.Set("Authorization", "Bearer "+key)
+		}
+	}
+
+	client := &http.Client{Timeout: upstreamTTL}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", p.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("%s: status %d: %s", p.Name, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var ur upstreamResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ur); err != nil {
+		return nil, fmt.Errorf("%s: decode: %w", p.Name, err)
+	}
+
+	// Fill in fields upstreams often omit so the merged output is uniform.
+	for i := range ur.Data {
+		if ur.Data[i].Object == "" {
+			ur.Data[i].Object = "model"
+		}
+		if ur.Data[i].OwnedBy == "" {
+			ur.Data[i].OwnedBy = defaultOwn
+		}
+	}
+	return ur.Data, nil
+}
+
+// mergeModels flattens per-provider slices and deduplicates by id.
+// First occurrence wins (preserves provider order from the providers list).
+// Empty IDs are skipped. Missing owned_by defaults to "agentgateway".
+func mergeModels(slices [][]Model) []Model {
+	seen := make(map[string]struct{}, 64)
+	out := make([]Model, 0, 64)
+	for _, s := range slices {
+		for _, m := range s {
+			if m.ID == "" {
+				continue
+			}
+			if _, ok := seen[m.ID]; ok {
+				continue
+			}
+			seen[m.ID] = struct{}{}
+			if m.OwnedBy == "" {
+				m.OwnedBy = defaultOwn
+			}
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// aggregate fetches all providers in parallel and merges their models.
+// Per-provider failures are logged and skipped — the merged result still
+// returns whatever the healthy providers had. Returns the merged slice
+// and the list of provider names that failed (in fetch order).
+func aggregate(ctx context.Context) (models []Model, failed []string) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results = make(map[string][]Model, len(providers))
+	)
+	wg.Add(len(providers))
+	for _, p := range providers {
+		p := p
+		go func() {
+			defer wg.Done()
+			ms, err := fetchProvider(ctx, p)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				slog.Warn("provider failed", "provider", p.Name, "err", err)
+				failed = append(failed, p.Name)
+				return
+			}
+			results[p.Name] = ms
+		}()
+	}
+	wg.Wait()
+
+	// Stitch slices back together in the original provider order.
+	var ordered [][]Model
+	for _, p := range providers {
+		if s, ok := results[p.Name]; ok {
+			ordered = append(ordered, s)
+		}
+	}
+	return mergeModels(ordered), failed
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func handleModels(cache *modelCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		now := time.Now()
+		if body, ok := cache.get(now); ok {
+			writeModels(w, body, "HIT")
+			return
+		}
+
+		// Bound the whole handler by the slowest upstream + a small margin
+		// so a stuck provider can't hold the request open past its timeout.
+		ctx, cancel := context.WithTimeout(r.Context(), upstreamTTL+time.Second)
+		defer cancel()
+
+		models, failed := aggregate(ctx)
+		if len(models) == 0 {
+			// Every provider failed — surface as 502 so the caller can
+			// distinguish "discovery dead" from "discovery healthy, no models".
+			slog.Error("all providers failed", "providers", failed)
+			http.Error(w, "all providers failed", http.StatusBadGateway)
+			return
+		}
+
+		payload, err := json.Marshal(outputResponse{Object: "list", Data: models})
+		if err != nil {
+			http.Error(w, "marshal failed", http.StatusInternalServerError)
+			return
+		}
+
+		cache.set(payload, now.Add(cacheTTL))
+		writeModels(w, payload, "MISS")
+	}
+}
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ok")
+}
+
+func writeModels(w http.ResponseWriter, body []byte, status string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=30")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+	slog.Info("served models", "cache", status, "bytes", len(body))
+}
+
+func main() {
+	// JSON to stdout for Promtail/Loki. Default-tag every line with the
+	// service name so downstream filters can scope to this workload.
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)).With("service", "agentgateway-discovery"))
+
+	addr := ":" + envOr("PORT", "8080")
+	cache := &modelCache{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", handleModels(cache))
+	mux.HandleFunc("/healthz", handleHealthz)
+	// Everything else falls through to a default 404 from net/http.
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		slog.Info("listening", "addr", addr, "providers", len(providers))
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	slog.Info("shutting down")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Warn("graceful shutdown error", "err", err)
+	}
+}

--- a/agentgateway-discovery/main.go
+++ b/agentgateway-discovery/main.go
@@ -28,20 +28,102 @@ const (
 )
 
 // Provider describes one upstream OpenAI-compatible /v1/models endpoint.
-// APIKeyEnv names an environment variable that — when set — supplies the
-// Bearer token sent to that provider. An empty APIKeyEnv disables auth.
+// APIKey is the literal Bearer token sent to that provider. An empty
+// APIKey disables auth (request goes out without an Authorization header).
 type Provider struct {
-	Name      string
-	URL       string
-	APIKeyEnv string
+	Name   string
+	URL    string
+	APIKey string
 }
 
-// providers is the static upstream set. Order is preserved in the merged
-// output so the response is stable for clients that key off position.
-var providers = []Provider{
-	{Name: "mlx", URL: "http://mac.internal:8080/v1/models", APIKeyEnv: ""},
-	{Name: "minimax", URL: "https://api.minimaxi.chat/v1/models", APIKeyEnv: "MINIMAX_API_KEY"},
-	{Name: "deepseek", URL: "https://api.deepseek.com/v1/models", APIKeyEnv: "DEEPSEEK_API_KEY"},
+// providers is populated at startup from env. The assignment happens before
+// any HTTP serving, so subsequent reads from request goroutines are safe.
+var providers []Provider
+
+// defaultProviders is the fallback used when no DISCOVERY_PROVIDER_* env
+// vars are set, so the service works out of the box with sensible defaults.
+func defaultProviders() []Provider {
+	return []Provider{
+		{Name: "mlx", URL: "http://mac.internal:8080/v1/models"},
+		{Name: "minimax", URL: "https://api.minimaxi.chat/v1/models"},
+		{Name: "deepseek", URL: "https://api.deepseek.com/v1/models"},
+	}
+}
+
+// loadProviders discovers providers from env vars of the form:
+//
+//	DISCOVERY_PROVIDER_<NAME>_URL=https://...          (required per provider)
+//	DISCOVERY_PROVIDER_<NAME>_API_KEY=<bearer-token>   (optional)
+//
+// <NAME> is lowercased on read. Order is the order in which URLs first
+// appear in os.Environ(). If no DISCOVERY_PROVIDER_* env vars are set at
+// all, returns defaultProviders(). A provider with an _API_KEY but no
+// _URL is a config error and aborts startup — better to crash loudly than
+// ship a silently-broken config.
+func loadProviders() []Provider {
+	type partial struct {
+		url    string
+		apiKey string
+		urlSet bool
+	}
+	byName := make(map[string]*partial)
+	var order []string
+
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key, val := kv[:eq], kv[eq+1:]
+		if !strings.HasPrefix(key, "DISCOVERY_PROVIDER_") {
+			continue
+		}
+		suffix := key[len("DISCOVERY_PROVIDER_"):]
+		var name, field string
+		switch {
+		case strings.HasSuffix(suffix, "_URL"):
+			name = strings.TrimSuffix(suffix, "_URL")
+			field = "url"
+		case strings.HasSuffix(suffix, "_API_KEY"):
+			name = strings.TrimSuffix(suffix, "_API_KEY")
+			field = "apikey"
+		default:
+			continue
+		}
+		if name == "" {
+			slog.Warn("ignoring DISCOVERY_PROVIDER env var with empty provider name", "key", key)
+			continue
+		}
+		name = strings.ToLower(name)
+		p, ok := byName[name]
+		if !ok {
+			p = &partial{}
+			byName[name] = p
+			order = append(order, name)
+		}
+		switch field {
+		case "url":
+			p.url = val
+			p.urlSet = true
+		case "apikey":
+			p.apiKey = val
+		}
+	}
+
+	if len(order) == 0 {
+		return defaultProviders()
+	}
+
+	out := make([]Provider, 0, len(order))
+	for _, name := range order {
+		p := byName[name]
+		if !p.urlSet {
+			slog.Error("DISCOVERY_PROVIDER env: provider has _API_KEY but no _URL", "provider", name)
+			os.Exit(1)
+		}
+		out = append(out, Provider{Name: name, URL: p.url, APIKey: p.apiKey})
+	}
+	return out
 }
 
 // Model is the OpenAI-compatible model object emitted in the response.
@@ -100,17 +182,15 @@ func (c *modelCache) set(b []byte, expiresAt time.Time) {
 }
 
 // fetchProvider GETs /v1/models from one upstream and returns its models.
-// Auth: if the named env var is set, send Authorization: Bearer <value>.
-// Otherwise the request goes out without an Authorization header.
+// Auth: if p.APIKey is set, send Authorization: Bearer <value>. Otherwise
+// the request goes out without an Authorization header.
 func fetchProvider(ctx context.Context, p Provider) ([]Model, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.URL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%s: build request: %w", p.Name, err)
 	}
-	if p.APIKeyEnv != "" {
-		if key := os.Getenv(p.APIKeyEnv); key != "" {
-			req.Header.Set("Authorization", "Bearer "+key)
-		}
+	if p.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.APIKey)
 	}
 
 	client := &http.Client{Timeout: upstreamTTL}
@@ -269,6 +349,7 @@ func main() {
 	// service name so downstream filters can scope to this workload.
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)).With("service", "agentgateway-discovery"))
 
+	providers = loadProviders()
 	addr := ":" + envOr("PORT", "8080")
 	cache := &modelCache{}
 


### PR DESCRIPTION
Replaces the agentgateway-discovery cronjob + busybox httpd static configmap flow with a live-aggregation service.

Behavior:
- GET /v1/models fans out to mlx / minimax / deepseek in parallel, merges results, deduplicates by id (first occurrence wins).
- Per-provider failures are logged at WARN and skipped — partial results still return as 200 with merged list.
- 30s in-memory TTL cache (sync.RWMutex) on the merged payload. Cache-Control: public, max-age=30.
- 10s per-upstream timeout.

Endpoints:
- GET /v1/models — OpenAI-compatible {object:list, data:[...]}
- GET /healthz — 200 ok (liveness + readiness probes)
- anything else — 404

Providers (configured in code, auth via env):
- mlx        http://mac.internal:8080/v1/models      (no auth)
- minimax    https://api.minimaxi.chat/v1/models     MINIMAX_API_KEY
- deepseek   https://api.deepseek.com/v1/models       DEEPSEEK_API_KEY

Stdlib-only — no external deps (sync.WaitGroup for parallel fetch, log/slog JSON handler for Promtail/Loki).

Build:
- Multi-arch go_binary targets (_linux_amd64, _linux_arm64)
- Distroless static base, ~19 MB
- :image / :load / :push targets match cronprint pattern

K8s integration (HelmRelease, HTTPRoute update, deletion of old models/{configmap,cronjob,deployment,service,rbac,backend}.yaml) is a separate follow-up.