### PR TITLE
ci(bazel): trigger push-images on agentgateway-discovery changes

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -66,6 +66,7 @@ jobs:
               - 'kobo/**'
               - 'line/**'
               - 'nodepool-autoscaler/**'
+              - 'agentgateway-discovery/**'
               - 'pii-adapter/**'
               - 'tools/**'
               - 'vgc/**'


### PR DESCRIPTION
The agentgateway-discovery service shipped in #579 but the bazel workflow's services path filter didn't include it, so the push-images job was skipped on the merge to main and the ghcr.io/solanyn/agentgateway-discovery image was never published.

Adding 'agentgateway-discovery/**' to the services filter so the next change under that path (and any future change on main now that the directory is present) will trigger push-images.

To publish the image that #579 should have produced, re-run the bazel workflow on the c73ca87 commit (or push any trivial follow-up to main) after this lands.