### PR TITLE
docs(agentgateway-discovery): fix secret key names in k8s example

### DIFF
--- a/agentgateway-discovery/README.md
+++ b/agentgateway-discovery/README.md
@@ -53,11 +53,11 @@ env:
   - name: DISCOVERY_PROVIDER_MINIMAX_URL
     value: "https://api.minimaxi.chat/v1/models"
   - name: DISCOVERY_PROVIDER_MINIMAX_API_KEY
-    valueFrom: { secretKeyRef: { name: minimax-auth, key: api-key } }
+    valueFrom: { secretKeyRef: { name: minimax-auth, key: MINIMAX_API_KEY } }
   - name: DISCOVERY_PROVIDER_DEEPSEEK_URL
     value: "https://api.deepseek.com/v1/models"
   - name: DISCOVERY_PROVIDER_DEEPSEEK_API_KEY
-    valueFrom: { secretKeyRef: { name: deepseek-auth, key: api-key } }
+    valueFrom: { secretKeyRef: { name: deepseek-auth, key: DEEPSEEK_API_KEY } }
 ```
 
 ## Endpoints


### PR DESCRIPTION
The README's k8s deployment snippet referenced secret keys named 'api-key', but llm/externalsecret.yaml actually exposes bare keys named MINIMAX_API_KEY / DEEPSEEK_API_KEY (the 'api-key' name was from an earlier draft of the spec). Updating the example to match what the home-ops HelmRelease already wires up.